### PR TITLE
add github workflow to detect empty PRs

### DIFF
--- a/.github/workflows/empty-test.yml
+++ b/.github/workflows/empty-test.yml
@@ -1,0 +1,31 @@
+name: Empty PR Check
+
+# This action checks for an empty commit
+
+on:
+    pull_request:
+        branches: ["*"]
+    merge_group:
+        branches: [main]
+jobs:
+    check-empty-pr:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout the code
+              uses: actions/checkout@v3
+              with:
+                fetch_depth: 2
+            - name: Get changed files
+              id: changed_files
+              uses: tj-actions/changed-files@v1
+            - name: Check if PR is empty
+              run: |
+                CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
+                if [ -z "$CHANGED_FILES" ]; then
+                    echo "No files changed in this PR."
+                    exit 1
+                else
+                    echo "Files changed in this PR:"
+                    echo "$CHANGED_FILES"
+                fi


### PR DESCRIPTION
# Summary

Mostly this PR is a test to verify that I can set up github workflows, which will helpful later on when we have some unit tests. For now, this will prevent us from merging empty PRs, which is more of a redundant check, useful for large projects with many people, but neutral in helpfulness for tune tracer.

# Test Plan

Verified that this PR passed the yaml test. Once this merges, I'll verify that it fails empty PRs.


-----
Please consider the impact of your changes on the other developers.