### PR TITLE
add user sign up to backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,10 @@
     "debug": "node --inspect-brk -r ts-node/register src/main.ts"
   },
   "devDependencies": {
-    "ts-node": "^10.9.2",
+    "ts-node": "^10.9.2"
+  },
+  "dependencies": {
+    "firebase": "^10.13.0",
     "typescript": "^5.5.4"
   }
 }

--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -1,0 +1,40 @@
+import firebase from 'firebase/compat/app'
+import 'firebase/compat/auth';
+import { FIREBASE_CONFIG } from '../firebaseSecrets'
+
+/*
+    Wrapper class for doing firebase stuff
+    Remember to call .initApp() before doing anything
+*/
+export default class FirebaseWrapper
+{
+    async initApp() : Promise<void>
+    {
+        if (firebase.apps.length === 0) {
+            await firebase.initializeApp(FIREBASE_CONFIG);
+        }
+    }
+
+    async signUpNewUser(email:string, password:string, displayName: string) : Promise<boolean>
+    {
+        try {
+            // user sign up
+            await firebase.auth().createUserWithEmailAndPassword(email, password);
+            const user = firebase.auth().currentUser;
+            if(!user)
+            {
+                throw Error('Something went wrong with user signup. User is null');
+            }
+    
+            // update username
+            await user.updateProfile({
+                displayName : displayName
+            });
+        } catch(error) {
+            console.log("Error creating user: ", (error as Error).message);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/backend/src/firebaseSecrets.ts
+++ b/backend/src/firebaseSecrets.ts
@@ -1,0 +1,12 @@
+export const FIREBASE_CONFIG = {
+
+    projectId: "l17-tune-tracer",
+    apiKey: "AIzaSyBPV_2yOAk8JeB0cJ2OBCdJQTCJyTNWDEg",
+    authDomain: "l17-tune-tracer.firebaseapp.com",
+    storageBucket: "l17-tune-tracer.appspot.com",
+    messagingSenderId: "268123826560",
+    appId: "1:268123826560:web:a75235657488bf0d727965",
+    measurementId: "G-68VYCRF92M"
+  
+  };
+  

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,1 +1,4 @@
+import { runTest } from './testController'
+
 console.log("Hello World!");
+// runTest();

--- a/backend/src/testController.ts
+++ b/backend/src/testController.ts
@@ -1,0 +1,7 @@
+import FirebaseWrapper from "./firebase-utils/FirebaseWrapper";
+export async function runTest()
+{
+    const firebase : FirebaseWrapper = new FirebaseWrapper();
+    await firebase.initApp();
+    firebase.signUpNewUser("chrisgittingsucf@gmail.com", "ThisIsAStrongPassword*50", "adminTest1");
+}


### PR DESCRIPTION
# Summary
Added a function for users to sign up.

Currently, `FirebaseWrapper` is acting as a wrapper function to handle all firebase calls. I will probably have to refactor it at some point when I figure out a better design pattern, but for now, it will act as an abstraction layer between firebase and our code.

The function `signUpNewUser` takes an email, password, and displayName and returns a boolean promise of whether or not the user creation was successful.

Further features could be added to this function.  Let me know if I should prioritize any, including:
* making display names optional
* adding some encryption or security component to handling passwords
* returning the actual error if the user creation was unsuccessful
* performing a retry of user creation if it unsuccessful (only for some types of errors)


# Test Plan

Uncommented the `runTest()` line in the main function, which ran the test. The test simply called the FirebaseWrapper `initApp` and `signUpNewUser` functions, with hard-coded user values.  I checked the Firebase auth database and confirmed that the new user was present in the database.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HUU9nRYPwony7mZP7U2e/d6c29724-7184-40ab-899b-40cf35d8e098.png)


-----
Please consider the impact of your changes on the other developers.