### PR TITLE
add log in function to firebase wrapper in backend

### DIFF
--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -37,4 +37,10 @@ export default class FirebaseWrapper
 
         return true;
     }
+
+    // will throw an error on a failed sign in
+    async signInUser(email: string, password: string) : Promise<void>
+    {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+    }
 }

--- a/backend/src/testController.ts
+++ b/backend/src/testController.ts
@@ -1,7 +1,26 @@
 import FirebaseWrapper from "./firebase-utils/FirebaseWrapper";
+
+const TEST_EMAIL = "chrisgittingsucf@gmail.com";
+const TEST_PASSWORD = "ThisIsAStrongPassword*50";
+
 export async function runTest()
 {
-    const firebase : FirebaseWrapper = new FirebaseWrapper();
+    const firebase: FirebaseWrapper = new FirebaseWrapper();
     await firebase.initApp();
-    firebase.signUpNewUser("chrisgittingsucf@gmail.com", "ThisIsAStrongPassword*50", "adminTest1");
+    await testLogIn(firebase);
+}
+
+async function testSignUp(firebase: FirebaseWrapper)
+{
+    await firebase.signUpNewUser(TEST_EMAIL, TEST_PASSWORD, "adminTest1");
+}
+
+async function testLogIn(firebase: FirebaseWrapper)
+{
+    await firebase.signInUser(TEST_EMAIL, TEST_PASSWORD)
+    .then(() => {
+        console.log("Sign in Successful!")
+    }).catch((error) => {
+        console.log(`Error caught: ${(error as Error).message}`)
+    });
 }


### PR DESCRIPTION
# Summary

Added sign in function to firebase wrapper.

In the future, I will need to add a way for devs to access the user credentials that are returned, either by returning the credentials or storing them in the wrapper, depending on what is necessary.

# Test Plan

Uncommented the `runTest()` call in the main file.  This called the sign in function, and I verified that the success print statement was called.

-----
Please consider the impact of your changes on the other developers.