### PR TITLE
add CRUD operations for composition documents

### DIFF
--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -1,10 +1,13 @@
 import firebase from 'firebase/compat/app'
 import 'firebase/compat/auth';
-import { FIREBASE_CONFIG } from '../firebaseSecrets'
+import 'firebase/compat/firestore';
+
+import { FIREBASE_CONFIG, DOCUMENT_DATABASE_NAME } from '../firebaseSecrets'
 
 /*
     Wrapper class for doing firebase stuff
     Remember to call .initApp() before doing anything
+    Note, all functions are async, so any returns are promises
 */
 export default class FirebaseWrapper
 {
@@ -43,4 +46,69 @@ export default class FirebaseWrapper
     {
         await firebase.auth().signInWithEmailAndPassword(email, password);
     }
+
+    async doesDocumentExist(documentId: string): Promise<boolean>
+    {
+        return (await firebase.firestore()
+                      .collection(DOCUMENT_DATABASE_NAME)
+                      .doc(documentId)
+                      .get()).exists;
+    }
+
+    // takes in the initial document information as a JSON object
+    // returns the document id of the created document
+    async createDocument(documentJSON: JSON): Promise<string>
+    {
+        const documentString = JSON.stringify(documentJSON);
+        const firestoreDocument = await firebase.firestore().collection(DOCUMENT_DATABASE_NAME).add({
+            documentString: documentString
+        });  
+        return firestoreDocument.id;
+    }
+
+    // takes in the new document
+    // returns true iff the document exists and the update was successful
+    async updateDocument(documentId: string, documentJSON: JSON): Promise<boolean>
+    {
+        const documentString = JSON.stringify(documentJSON);
+        if(!await this.doesDocumentExist(documentId))
+        {
+            return false;
+        }
+        await firebase.firestore()
+                      .collection(DOCUMENT_DATABASE_NAME)
+                      .doc(documentId)
+                      .update({"documentString" : documentString});
+        return true;
+    }
+
+    // takes in the document unique id and returns the associated document as a JSON object
+    // if the document or data doesn't exist, the function returns null
+    async getDocument(documentId: string): Promise<JSON | null>
+    {
+        const document = (await firebase.firestore()
+        .collection(DOCUMENT_DATABASE_NAME)
+        .doc(documentId)
+        .get());
+        
+        if(!document.exists)
+        {
+            return null;
+        } 
+
+        const data = document.data();
+        if(data === undefined || !('documentString' in data))
+        {
+            return null;
+        }
+        
+        return data['documentString'];
+    }
+    
+    // deletes the document associated with the documentId
+    // throws an error if the document deletion was unsuccessful
+    async deleteDocument(documentId: string): Promise<void>
+    {
+        await firebase.firestore().collection(DOCUMENT_DATABASE_NAME).doc(documentId).delete();
+    }   
 }

--- a/backend/src/firebaseSecrets.ts
+++ b/backend/src/firebaseSecrets.ts
@@ -1,0 +1,13 @@
+export const FIREBASE_CONFIG = {
+
+    projectId: "l17-tune-tracer",
+    apiKey: "AIzaSyBPV_2yOAk8JeB0cJ2OBCdJQTCJyTNWDEg",
+    authDomain: "l17-tune-tracer.firebaseapp.com",
+    storageBucket: "l17-tune-tracer.appspot.com",
+    messagingSenderId: "268123826560",
+    appId: "1:268123826560:web:a75235657488bf0d727965",
+    measurementId: "G-68VYCRF92M"
+};
+
+export const DOCUMENT_DATABASE_NAME = "Composition_Documents";
+  

--- a/backend/src/testController.ts
+++ b/backend/src/testController.ts
@@ -7,7 +7,8 @@ export async function runTest()
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     await firebase.initApp();
-    await testLogIn(firebase);
+    await testDocumentRead(firebase);
+    process.exit(0);
 }
 
 async function testSignUp(firebase: FirebaseWrapper)
@@ -23,4 +24,61 @@ async function testLogIn(firebase: FirebaseWrapper)
     }).catch((error) => {
         console.log(`Error caught: ${(error as Error).message}`)
     });
+}
+
+async function testDocumentAdd(firebase: FirebaseWrapper)
+{
+    const exampleDocument = JSON.parse(JSON.stringify({
+        owner: "someemail@example.com",
+        title: "Document Title",
+        content: {
+            music: "ABCDEFG",
+            notes: [0, 1, 2, 3, 4, 5],
+            something: 1
+        }
+    }));
+    const id = await firebase.createDocument(exampleDocument);
+    console.log(`Document Id: ${id}`);
+}
+
+async function testDocumentUpdate(firebase: FirebaseWrapper)
+{
+    const exampleDocument = JSON.parse(JSON.stringify({
+        owner: "someemail@example.com",
+        title: "Document Title",
+        content: {
+            music: "ABCDEFG",
+            notes: [0, 1, 2, 3, 4, 5],
+            something: 1
+        }
+    }));
+    const id = await firebase.createDocument(exampleDocument);
+    console.log(`Document Id: ${id}`);
+
+    exampleDocument.title = "New Document Title";
+    const success = await firebase.updateDocument(id, exampleDocument);
+    console.log(`Document Update was successful: ${success ? "true" : "false"}`);
+}
+
+async function testDocumentDeletion(firebase: FirebaseWrapper)
+{
+    const exampleDocument = JSON.parse(JSON.stringify({
+        owner: "someemail@example.com",
+        title: "Document Title",
+        content: {
+            music: "ABCDEFG",
+            notes: [0, 1, 2, 3, 4, 5],
+            something: 1
+        }
+    }));
+    const id = await firebase.createDocument(exampleDocument);
+    console.log(`Document Id: ${id}`);
+    const success = await firebase.deleteDocument(id);
+}
+
+async function testDocumentRead(firebase: FirebaseWrapper)
+{
+    const knownId = "hlWB73fSeHpknyFELFk1";
+    const data = await firebase.getDocument(knownId);
+    console.log(`Document Data: ${data ? JSON.stringify(data) : "null"}`);
 }


### PR DESCRIPTION
# Summary

Added support for simple CRUD operations for music documents.

Each document has a string id that is generated upon the first creation of the document. Any future reads, deletions, and updates require this id to occur.

***NOTE***: This support is meant for the backend only. I will add an additional layer of functions to actually be called by the APIs.

# Test Plan

Used the functions in the `testController` file to test the CRUD functions. I have not yet tested what happens on a failure.

-----
Please consider the impact of your changes on the other developers.