### PR TITLE
add abstraction layer to document CRUD operations for api endpoints/frontend

### DIFF
--- a/backend/src/document-utils/documentOperations.ts
+++ b/backend/src/document-utils/documentOperations.ts
@@ -1,0 +1,70 @@
+import { dataToDocument, documentToData } from "../firebase-utils/documentConversionUtils";
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+import { Document, DocumentMetadata, SHARE_STYLE } from './documentTypes'; 
+
+// takes in the user id who triggered the document creation and returns a
+// promise containing a default (blank) document as a Document
+export async function createDocument(creatorId: string): Promise<Document>
+{
+    const firebase: FirebaseWrapper = new FirebaseWrapper();
+    firebase.initApp();
+    const documentId = await firebase.createDocument();
+
+    const currentTime = Date.now();
+    const metadata: DocumentMetadata = {
+        document_id: documentId,
+        owner_email: creatorId,
+        share_style: SHARE_STYLE.private_document,
+        time_created: currentTime,
+        last_edit_time: currentTime,
+    };
+    const document : Document = {
+        document_title: "",
+        contents: JSON.parse(JSON.stringify("{}")),
+        comments: [],
+        metadata: metadata
+    };
+
+    await firebase.updateDocument(documentId, documentToData(document));
+    return document;
+}
+
+// takes in the updated documet and returns a promise containing true iff the document was
+// successfully updated
+// assumes the writing user has already been authenticated
+export async function updateDocument(updatedDocument: Document): Promise<boolean>
+{
+    const firebase: FirebaseWrapper = new FirebaseWrapper();
+    firebase.initApp();
+
+    const documentId = updatedDocument.metadata.document_id;
+    return firebase.updateDocument(documentId, documentToData(updatedDocument));
+}
+
+// returns a promise containing the Document associated with the documentId
+// assumes proper access has already been verified
+// throws an error if document retrieval failed
+export async function getDocument(documentId: string): Promise<Document>
+{
+    const firebase: FirebaseWrapper = new FirebaseWrapper();
+    firebase.initApp();
+
+    const firebaseDocument = await firebase.getDocument(documentId);
+    if(firebaseDocument === null)
+    {
+        throw Error(`Error retrieving firebase document ${documentId}. Make sure the document associated with the id and the internet connection is good.`)
+    }
+
+    const document = dataToDocument(firebaseDocument);
+    return document;
+}
+
+// deletes the document associated with the given document id
+// assumes the user owns the document
+export async function deleteDocument(documentId: string): Promise<void>
+{
+    const firebase: FirebaseWrapper = new FirebaseWrapper();
+    firebase.initApp();
+
+    await firebase.deleteDocument(documentId);
+}

--- a/backend/src/document-utils/documentTypes.ts
+++ b/backend/src/document-utils/documentTypes.ts
@@ -1,0 +1,48 @@
+// purpose: for defining how a document has been shared
+export enum SHARE_STYLE 
+{
+    private_document = 1,   // the document has not been shared
+    public_document = 2,    // the document has been shared publically without the need to auth checks 
+    view_list = 3,          // the document can be viewed only by a select group of users
+    comment_list = 4,       // the document can be commented on (and viewed) by a select group of users
+    edit_list = 5,          // the document can be edited by (read/write access) a select group of users
+};
+
+// purpose: for storing information about comments inside a composition document
+export type Comment = 
+{
+    comment_id: string,
+    content: string,
+    author_email: string,
+    is_reply: boolean,
+    reply_id?: string,
+    time_created: number,
+    last_edit_time: number,
+};
+
+// purpose for storing metadata about a composition document
+export type DocumentMetadata =
+{
+    document_id: string,
+    owner_email: string,
+    share_style: SHARE_STYLE,
+    share_list?: string[],
+    time_created: number,
+    last_edit_time: number,
+};
+
+// purpose: manipulate composition documents in the code
+export type Document =
+{
+    document_title: string,
+    contents: JSON,
+    comments: Comment[],
+    metadata: DocumentMetadata,
+};
+
+// purpose: for storing a document in firestore
+export type FirebaseDocumentData =
+{
+    documentString: string,
+    metadata: string
+};

--- a/backend/src/firebase-utils/documentConversionUtils.ts
+++ b/backend/src/firebase-utils/documentConversionUtils.ts
@@ -1,0 +1,28 @@
+import type { Document, FirebaseDocumentData, Comment } from '../document-utils/documentTypes'
+
+// converts a Document to FirebaseDocumentData and returns the result
+export function documentToData(document: Document) : FirebaseDocumentData
+{
+    const documentCopy = JSON.parse(JSON.stringify(document));
+    const metadata = documentCopy.metadata;
+    delete documentCopy['metadata'];
+    const data : FirebaseDocumentData = {
+        documentString: JSON.stringify(documentCopy),
+        metadata: JSON.stringify(metadata)
+    };
+    return data;
+}
+
+// converts a FirebaseDocumentData object to a Document and returns the result
+export function dataToDocument(data: FirebaseDocumentData) : Document
+{
+    const documentContent = JSON.parse(data.documentString);
+    const document : Document = 
+    {
+        document_title: documentContent['document_title'],
+        contents: documentContent['contents'],
+        comments: documentContent['comments'] as Comment[],
+        metadata: JSON.parse(data.metadata)
+    };
+    return document;
+}

--- a/backend/src/security-utils/permissionVerification.ts
+++ b/backend/src/security-utils/permissionVerification.ts
@@ -1,0 +1,74 @@
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+import { DocumentMetadata, SHARE_STYLE } from "../document-utils/documentTypes";
+
+// returns true iff a user has read access
+// takes in the email of a user and the id of the document to check
+async function userHasReadAccess(userId: string, documentId: string)
+{
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+
+    const metadata: DocumentMetadata | null = await firebase.getDocumentMetadata(documentId);
+    if(metadata === null) {
+        return false;
+    }
+
+    if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document)
+    {
+        return true;
+    } else if(metadata.share_style === SHARE_STYLE.view_list 
+           || metadata.share_style === SHARE_STYLE.comment_list 
+           || metadata.share_style === SHARE_STYLE.edit_list )
+    {
+        return metadata.share_list?.includes(userId) ?? false;
+    }
+
+    return false;
+}
+
+// returns true iff a user has comment access
+// takes in the email of a user and the id of the document to check
+async function userHasCommentAccess(userId: string, documentId: string)
+{
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+
+    const metadata : DocumentMetadata | null = await firebase.getDocumentMetadata(documentId);
+    if(metadata === null) {
+        return false;
+    }
+
+    if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document)
+    {
+        return true;
+    } else if(metadata.share_style === SHARE_STYLE.comment_list 
+           || metadata.share_style === SHARE_STYLE.edit_list )
+    {
+        return metadata.share_list?.includes(userId) ?? false;
+    }
+
+    return false;
+}
+
+// returns true iff a user has edit access
+// takes in the email of a user and the id of the document to check
+async function userHasEditAccess(userId: string, documentId: string)
+{
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+
+    const metadata : DocumentMetadata | null = await firebase.getDocumentMetadata(documentId);
+    if(metadata === null) {
+        return false;
+    }
+
+    if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document)
+    {
+        return true;
+    } else if(metadata.share_style === SHARE_STYLE.edit_list )
+    {
+        return metadata.share_list?.includes(userId) ?? false;
+    }
+
+    return false;
+}

--- a/backend/src/testController.ts
+++ b/backend/src/testController.ts
@@ -1,13 +1,45 @@
 import FirebaseWrapper from "./firebase-utils/FirebaseWrapper";
+import { Document, FirebaseDocumentData, Comment } from './document-utils/documentTypes';
+import { documentToData, dataToDocument } from "./firebase-utils/documentConversionUtils";
+import { createDocument, updateDocument, deleteDocument, getDocument } from './document-utils/documentOperations';
 
 const TEST_EMAIL = "chrisgittingsucf@gmail.com";
 const TEST_PASSWORD = "ThisIsAStrongPassword*50";
 
+const TEST_DOCUMENT: Document = {
+    contents: JSON.parse(JSON.stringify({
+        json_list: ["help", "me", "plz"],
+        user_id: "@email.com"
+    })),
+    comments: [
+        {
+            comment_id: "1234",
+            content: "help me I'm a comment",
+            author_email: "example@example.com",
+            is_reply: false,
+            time_created: 1234556,
+            last_edit_time: 1234556,
+        }
+    ],
+    metadata: {
+        document_id: "test_document_id",
+        owner_email: "example@example.com",
+        share_style: 1,
+        time_created: 0,
+        last_edit_time: 12,
+    },
+    document_title: "Document Title",
+};
+
 export async function runTest()
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
-    await firebase.initApp();
-    await testDocumentRead(firebase);
+    firebase.initApp();
+    await testDocumentUpdate(firebase);
+    await testDocumentAdd(firebase);
+    // await testDocumentDeletion(firebase);
+    // await testDocumentRead(firebase);
+    testDocumentConversion(firebase);
     process.exit(0);
 }
 
@@ -28,57 +60,58 @@ async function testLogIn(firebase: FirebaseWrapper)
 
 async function testDocumentAdd(firebase: FirebaseWrapper)
 {
-    const exampleDocument = JSON.parse(JSON.stringify({
-        owner: "someemail@example.com",
-        title: "Document Title",
-        content: {
-            music: "ABCDEFG",
-            notes: [0, 1, 2, 3, 4, 5],
-            something: 1
-        }
-    }));
-    const id = await firebase.createDocument(exampleDocument);
-    console.log(`Document Id: ${id}`);
+    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    console.log(`Document Id: ${doc.metadata.document_id}`);
 }
 
 async function testDocumentUpdate(firebase: FirebaseWrapper)
 {
-    const exampleDocument = JSON.parse(JSON.stringify({
-        owner: "someemail@example.com",
-        title: "Document Title",
-        content: {
-            music: "ABCDEFG",
-            notes: [0, 1, 2, 3, 4, 5],
-            something: 1
-        }
-    }));
-    const id = await firebase.createDocument(exampleDocument);
-    console.log(`Document Id: ${id}`);
+    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    console.log(`Document Id: ${doc.metadata.document_id}`);
+    TEST_DOCUMENT.metadata.document_id = doc.metadata.document_id;
+    await updateDocument(TEST_DOCUMENT);
 
-    exampleDocument.title = "New Document Title";
-    const success = await firebase.updateDocument(id, exampleDocument);
+    const updatedDocumentTest = JSON.parse(JSON.stringify(TEST_DOCUMENT)) as Document;
+
+    updatedDocumentTest.document_title = "New Document Title";
+    const success = await updateDocument(updatedDocumentTest);
     console.log(`Document Update was successful: ${success ? "true" : "false"}`);
 }
 
 async function testDocumentDeletion(firebase: FirebaseWrapper)
 {
-    const exampleDocument = JSON.parse(JSON.stringify({
-        owner: "someemail@example.com",
-        title: "Document Title",
-        content: {
-            music: "ABCDEFG",
-            notes: [0, 1, 2, 3, 4, 5],
-            something: 1
-        }
-    }));
-    const id = await firebase.createDocument(exampleDocument);
-    console.log(`Document Id: ${id}`);
-    const success = await firebase.deleteDocument(id);
+    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    console.log(`Document Id: ${doc.metadata.document_id}`);
+    await deleteDocument(doc.metadata.document_id);
 }
 
 async function testDocumentRead(firebase: FirebaseWrapper)
 {
-    const knownId = "hlWB73fSeHpknyFELFk1";
-    const data = await firebase.getDocument(knownId);
-    console.log(`Document Data: ${data ? JSON.stringify(data) : "null"}`);
+    const knownId = "mdToBjiuptSO6FgXlt43";
+    const document = await getDocument(knownId);
+    console.log(`Document Data: ${JSON.stringify(document)}`);
+}
+
+function testDocumentConversion(firebase: FirebaseWrapper)
+{
+    const result = dataToDocument(documentToData(TEST_DOCUMENT));
+
+    if(JSON.stringify(sortKeysOfDocument(TEST_DOCUMENT)) 
+        === JSON.stringify(sortKeysOfDocument(result)))
+    {
+        console.log(`Test was successful: starting document was converted to and from firebase style correctly`);
+    } else
+    {
+        throw Error(`Error: conversion failed`);
+    }
+}
+
+function sortKeysOfDocument(document: Document): Document
+{
+    // Create a new object with sorted keys
+    const documentCopy = Object.keys(document).sort().reduce((acc, key) => {
+        acc[key] = (document as any)[key];
+        return acc;
+    }, {} as Record<string, any>);
+    return JSON.parse(JSON.stringify(documentCopy)) as Document;
 }


### PR DESCRIPTION
# Summary
Added a file `documentOperations.ts` for the frontend/APIs to access and use. This file will do all the firebase interactions for the developer, so you don't have to interact directly with firebase at all.

Additionally, developers will want to use the `Document` schema (type) defined in the `documentTypes.ts` file, which is how the document data will be passed around. 