### PR TITLE
add optional preview customizations in document type defintion

### DIFF
--- a/lib/documentTypes.ts
+++ b/lib/documentTypes.ts
@@ -17,6 +17,8 @@ export type DocumentMetadata =
     time_created: number,       // the time (in milliseconds) when the document was created
     last_edit_time: number,     // the time (in milliseconds) when the document was last updated
     last_edit_user: string,     // the user that last updated the document
+    preview_emoji?: string,     // the emoji that represents this document | visible on the storage page
+    preview_color?: string,     // the color that the user chose for this document | visible on the storage page
 };
 
 // purpose: for defining how a document has been shared


### PR DESCRIPTION
# Summary
I added metadata for an emoji and color for the document preview on the storage page. They are currently set as optional parameters, so devs should make sure to check if they are `undefined` when using them.

Edits to these variables is currently not supported (metadata updates coming soon), but they can be accessed along with the rest of the document metadata.

# Test Plan
No test. Compiler should catch errors.

-----
Please consider the impact of your changes on the other developers.