### PR TITLE
fix pnpm install issue (add node types to dev dependencies)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "debug": "node --inspect-brk -r ts-node/register src/main.ts"
   },
   "devDependencies": {
+    "@types/node": "^22.5.4",
     "ts-node": "^10.9.2"
   },
   "dependencies": {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",                          // Specifies the target JavaScript language version.
     "module": "CommonJS",                        // Specifies the module system to use (CommonJS for Node.js, ESNext for ES Modules).
+    "types": ["node"],
     "strict": true,                              // Enables strict type-checking options.
     "esModuleInterop": true,                     // Enables interoperability between CommonJS and ES Modules.
     "skipLibCheck": true,                        // Skips type checking of declaration files (.d.ts) for faster compilation.


### PR DESCRIPTION
# Summary
After deleting my local node_modules folder, the compiler was complaining that it could not recognize the `process.exit(0)` command in the `testController.ts` file, so I installed nodes/types as a dev dependency. This may need to be converted to a prod dependency in the future.


# Test Plan
Used `pnpm install` and `pnpm build`.

-----
Please consider the impact of your changes on the other developers.