### PR TITLE
fix pnpm scripts for backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,19 +3,23 @@
   "version": "0.0.1",
   "description": "backend components of tune tracer",
   "main": "main.ts",
+  "_moduleAliases": {
+  "@lib": "../lib"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "start": "node dist/main.js",
-    "dev": "tsc && pnpm start",
-    "debug": "node --inspect-brk -r ts-node/register src/main.ts"
+    "start": "node -r module-alias/register dist/main.js",
+    "dev": "ts-node -r module-alias/register src/main.ts",
+    "debug": "node --inspect-brk -r module-alias/register -r ts-node/register src/main.ts"
   },
   "devDependencies": {
-    "@types/node": "^22.5.4",
     "ts-node": "^10.9.2"
   },
   "dependencies": {
+    "@types/node": "^22.5.4",
     "firebase": "^10.13.0",
+    "module-alias": "^2.2.3",
     "typescript": "^5.5.4"
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,4 @@
 import { runTest } from './testController'
 
 console.log("Hello World!");
-// runTest();
+runTest();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,16 +8,17 @@
     "skipLibCheck": true,                        // Skips type checking of declaration files (.d.ts) for faster compilation.
     "forceConsistentCasingInFileNames": true,    // Ensures consistent casing in file names.
     "outDir": "./dist",                          // Specifies the output directory for compiled JavaScript files.
+    "rootDir": "../",
     "moduleResolution": "node",                  // Specifies module resolution strategy: "node" for Node.js-style resolution.
     "resolveJsonModule": true,                   // Allows importing JSON files as modules.
     "sourceMap": true,                           // Generates corresponding .map files for debugging.
     "noImplicitAny": true,                       // Raises errors on expressions and declarations with an implied `any` type.
     "strictNullChecks": true,                    // Ensures that `null` and `undefined` are only assignable to `void` or their own types.
-    "baseUrl": "./src",
+    "baseUrl": "./",
     "paths": {
-      "@lib/*": ["../../lib/*"]
+      "@lib/*": ["../lib/*"]
     }
   },
-  "include": ["src/**/*.ts", "../../lib/*"],        // Specifies which files to include in the project.
+  "include": ["src/**/*.ts", "../lib/**/*.ts"],        // Specifies which files to include in the project.
   "exclude": ["node_modules", "dist"]            // Specifies which files or directories to exclude from the project.
 }


### PR DESCRIPTION
# Summary

pnpm scripts were not working properly after the previous tsconfig edits. I had to add aliases and fix the rootDir & baseDir in the tsconfig file.

# Test Plan

Deleted all `dist` and `node_modules` folders and then ran the following commands while in the backend directory:
1. `pnpm install`
2. `pnpm build`
3. `pnpm dev`
4. `pnpm debug`

Got no errors for all commands

-----
Please consider the impact of your changes on the other developers.