### PR TITLE
add functions for updating document metadata (backend)

### DIFF
--- a/backend/src/document-utils/updateDocumentMetadata.ts
+++ b/backend/src/document-utils/updateDocumentMetadata.ts
@@ -1,0 +1,42 @@
+import { Document, DocumentMetadata, SHARE_STYLE } from "@lib/documentTypes";
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+
+import firebase from 'firebase/compat/app'
+import 'firebase/compat/firestore';
+
+// TO DO: verify that key passed in to updateDocumentMetadata is valid
+
+const getFirebase = () : FirebaseWrapper => {
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+    return firebase;
+};
+
+// generic version of all following functions; updates a metadata field for a document
+async function updateDocumentMetadata(documentId: string, key: string, newValue: unknown) {
+    const firebase = getFirebase();
+    const firebaseKey = `metadata.${key}`;
+    return firebase.updateDocumentMetadataField(documentId, {[firebaseKey]: newValue});
+}
+
+export async function updateDocumentShareStyle(documentId: string, newShareStyle: SHARE_STYLE) {
+    return updateDocumentMetadata(documentId, 'share_style', newShareStyle);
+}
+
+export async function updateDocumentEmoji(documentId: string, newEmoji: string) {
+    return updateDocumentMetadata(documentId, 'preview_emoji', newEmoji);
+}
+
+export async function updateDocumentColor(documentId: string, newColor: string) {
+    return updateDocumentMetadata(documentId, 'preview_color', newColor);
+}
+
+// assumption: only call this function if the user is not already in the share list
+// assumption: only share with existing users
+export async function shareDocumentWithUser(documentId: string, newUser: string) {
+    return updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayUnion(newUser));
+}
+
+export async function unshareDocumentWithUser(documentId: string, newUser: string) {
+    return updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayRemove(newUser));
+}


### PR DESCRIPTION
# Summary

Added functions that allow updates to a document's metadata. Specifically, updates to the:
* preview emoji
* preview color
* share style
* share user list

# Test Plan
Ran the `testDocumentMetadataUpdate` function in the `testController.ts` file, which called all the new update functions. I then verified that the changes were reflected in Firestore.


-----
Please consider the impact of your changes on the other developers.