### PR TITLE
formally define user entities in firestore

### DIFF
--- a/lib/UserEntity.ts
+++ b/lib/UserEntity.ts
@@ -1,0 +1,25 @@
+/*
+    the UserEntity is the type that describes a user account.
+    It represents
+*/
+export type UserEntity =
+{
+    user_email: string,                 // the email associated with this user account
+    display_name: string,               // the display name for this user
+    account_creation_time: number,      // the time (in milliseconds) when this account was created
+    owned_documents: string[],          // a list of the document ids associated with all documents that the user created
+    shared_documents: string[],         // a list of the document ids associated with all documents that have been shared with this user
+};
+
+// purpose: returns the default user (ie a blank user) for use in account creation
+// this helps populate the database with the default user information 
+export function getDefaultUser(): UserEntity
+{
+    return {
+        user_email: "",
+        display_name: "",
+        owned_documents: [],
+        shared_documents: [],
+        account_creation_time: Date.now()
+    }
+}


### PR DESCRIPTION
# Summary

I added a type definition for a user entity, which is how user account information (other than passwords and emails) will now be stored. This will make updating the user account information (like the shared and owned documents) easier.

# Test Plan

Ran the `testSignUp` function in the `testController.ts` file.

-----
Please consider the impact of your changes on the other developers.