### PR TITLE
[Bug Fix] update the user lists when updating the document sharing metadata

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "backend components of tune tracer",
   "main": "main.ts",
   "_moduleAliases": {
-  "@lib": "../lib"
+    "@lib": "../lib"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -14,6 +14,8 @@
     "debug": "node --inspect-brk -r module-alias/register -r ts-node/register src/main.ts"
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.7",
+    "lodash": "^4.17.21",
     "ts-node": "^10.9.2"
   },
   "dependencies": {

--- a/backend/src/document-utils/updateDocumentMetadata.ts
+++ b/backend/src/document-utils/updateDocumentMetadata.ts
@@ -6,7 +6,7 @@ import 'firebase/compat/firestore';
 
 // TO DO: verify that key passed in to updateDocumentMetadata is valid
 
-const getFirebase = () : FirebaseWrapper => {
+const getFirebase = (): FirebaseWrapper => {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
     return firebase;
@@ -16,27 +16,33 @@ const getFirebase = () : FirebaseWrapper => {
 async function updateDocumentMetadata(documentId: string, key: string, newValue: unknown) {
     const firebase = getFirebase();
     const firebaseKey = `metadata.${key}`;
-    return firebase.updateDocumentMetadataField(documentId, {[firebaseKey]: newValue});
+    await firebase.updateDocumentMetadataField(documentId, {[firebaseKey]: newValue});
 }
 
 export async function updateDocumentShareStyle(documentId: string, newShareStyle: SHARE_STYLE) {
-    return updateDocumentMetadata(documentId, 'share_style', newShareStyle);
+    await updateDocumentMetadata(documentId, 'share_style', newShareStyle);
 }
 
 export async function updateDocumentEmoji(documentId: string, newEmoji: string) {
-    return updateDocumentMetadata(documentId, 'preview_emoji', newEmoji);
+    await updateDocumentMetadata(documentId, 'preview_emoji', newEmoji);
 }
 
 export async function updateDocumentColor(documentId: string, newColor: string) {
-    return updateDocumentMetadata(documentId, 'preview_color', newColor);
+    await updateDocumentMetadata(documentId, 'preview_color', newColor);
 }
 
 // assumption: only call this function if the user is not already in the share list
 // assumption: only share with existing users
 export async function shareDocumentWithUser(documentId: string, newUser: string) {
-    return updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayUnion(newUser));
+    await Promise.all([
+            updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayUnion(newUser)),
+            getFirebase().insertUserDocument(newUser, documentId, false)
+        ]);
 }
 
-export async function unshareDocumentWithUser(documentId: string, newUser: string) {
-    return updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayRemove(newUser));
+export async function unshareDocumentWithUser(documentId: string, oldUser: string) {
+    await Promise.all([
+            updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayRemove(oldUser)),
+            getFirebase().deleteUserDocument(oldUser, documentId, false)
+        ]);
 }

--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -12,7 +12,6 @@ import { getDefaultUser, UserEntity } from '@lib/UserEntity';
     Remember to call .initApp() before doing anything
     Note, all functions are async, so any returns are promises
 */
-
 export default class FirebaseWrapper
 {
     public initApp(): void
@@ -99,7 +98,7 @@ export default class FirebaseWrapper
         const firestoreDocument = await firebase
             .firestore()
             .collection(DOCUMENT_DATABASE_NAME)
-            .add({});  
+            .add({});
         return firestoreDocument.id;
     }
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,4 @@
-import { runTest } from './testController'
+import { runTest } from './tests/testController'
 
 console.log("Hello World!");
 runTest();

--- a/backend/src/tests/testController.ts
+++ b/backend/src/tests/testController.ts
@@ -1,14 +1,19 @@
-import FirebaseWrapper from "./firebase-utils/FirebaseWrapper";
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { Document,  Comment, SHARE_STYLE } from '@lib/documentTypes';
-import { createDocument, updateDocument, deleteDocument, getDocument } from './document-utils/documentOperations';
-import { getDocumentsOwnedByUser, getDocumentsSharedWithUser } from "./document-utils/documentBatchRead";
+import { createDocument, updateDocument, deleteDocument, getDocument } from '../document-utils/documentOperations';
+import { getDocumentsOwnedByUser, getDocumentsSharedWithUser } from "../document-utils/documentBatchRead";
 import { updateDocumentShareStyle, 
          updateDocumentEmoji, 
          updateDocumentColor, 
          shareDocumentWithUser, 
-         unshareDocumentWithUser } from './document-utils/updateDocumentMetadata';
-const TEST_EMAIL = "chrisgittingsucf@gmail.com";
-const TEST_PASSWORD = "ThisIsAStrongPassword*50";
+         unshareDocumentWithUser } from '../document-utils/updateDocumentMetadata';
+
+import { isEqual } from 'lodash';
+
+const PRIMARY_TEST_EMAIL = "test-user-1@tune-tracer.com";
+const TEST_PASSWORD = "This*Is*A*Strong*Password100!";
+const SECONDARY_TEST_EMAIL = "test-user-2@tune-tracer.com";
+const TERTIARY_TEST_EMAIL = "test-user-3@tune-tracer.com";
 
 // to test: 
 // check sign up correctly add user in user collection
@@ -24,7 +29,7 @@ const TEST_DOCUMENT: Document = {
         {
             comment_id: "1234",
             content: "help me I'm a comment",
-            author_email: TEST_EMAIL,
+            author_email: PRIMARY_TEST_EMAIL,
             is_reply: false,
             time_created: 1234556,
             last_edit_time: 1234556,
@@ -32,11 +37,11 @@ const TEST_DOCUMENT: Document = {
     ],
     metadata: {
         document_id: "test_document_id",
-        owner_email: TEST_EMAIL,
+        owner_email: PRIMARY_TEST_EMAIL,
         share_style: 1,
         time_created: 0,
         last_edit_time: 12,
-        last_edit_user: TEST_EMAIL,
+        last_edit_user: PRIMARY_TEST_EMAIL,
     },
     document_title: "Document Title",
 };
@@ -45,25 +50,27 @@ export async function runTest()
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
+    await testDocumentMetadataUpdates(firebase);
+
     // await testSignUp(firebase);
     // await testDocumentAdd(firebase);
     // await testDocumentDeletion(firebase);
     // await testDocumentBatchOperations(firebase);
     // await testDocumentRead(firebase);
     // await testDocumentUpdate(firebase);
-    await testDocumentMetadataUpdate(firebase);
+    // await testDocumentMetadataUpdate(firebase);
     // testDocumentConversion(firebase);
     process.exit(0);
 }
 
 async function testSignUp(firebase: FirebaseWrapper)
 {
-    await firebase.signUpNewUser(TEST_EMAIL, TEST_PASSWORD, "adminTest1");
+    await firebase.signUpNewUser(PRIMARY_TEST_EMAIL, TEST_PASSWORD, "adminTest1");
 }
 
 async function testLogIn(firebase: FirebaseWrapper)
 {
-    await firebase.signInUser(TEST_EMAIL, TEST_PASSWORD)
+    await firebase.signInUser(PRIMARY_TEST_EMAIL, TEST_PASSWORD)
     .then(() => {
         console.log("Sign in Successful!")
     }).catch((error) => {
@@ -106,10 +113,10 @@ async function testDocumentMetadataUpdate(firebase: FirebaseWrapper)
         updateDocumentColor(id, "blue"),
         updateDocumentEmoji(id, "&#x1f602"),
         shareDocumentWithUser(id, "jeff@sample.com"),
-        shareDocumentWithUser(id, TEST_EMAIL)
+        shareDocumentWithUser(id, PRIMARY_TEST_EMAIL)
     ];
     await Promise.resolve(promises);
-    await unshareDocumentWithUser(id, TEST_EMAIL);
+    await unshareDocumentWithUser(id, PRIMARY_TEST_EMAIL);
 
     const result = await getDocument(id);
     console.log(`Resulting Document: ${result.metadata.document_id}`);
@@ -129,6 +136,36 @@ async function testDocumentRead(firebase: FirebaseWrapper)
     console.log(`Document Data: ${JSON.stringify(document)}`);
 }
 
+
+async function testDocumentBatchOperations(firebase: FirebaseWrapper): Promise<void>
+{
+    const userId = PRIMARY_TEST_EMAIL;
+    const owned = await getDocumentsOwnedByUser(userId);
+    console.log(`Owned Documents: ${owned.map((doc) => doc.metadata.document_id).join(',')}`)
+}
+
+/*
+Start of Automated Unit Testing
+
+TODO
+* Control these tests with the pnpm test call
+* automatically run tests before merging (yaml)
+* Functions to add to these tests:
+* update metadata functions (x4)
+* addDocument, deleteDocument, getDocument in documentOperations.ts
+* user permission functions in permissionVerification.ts
+*/
+
+/* UTILITIES */
+// there's probably a better way to do this
+function assert(condition: any, msg?: string): asserts condition {
+    if (!condition) {
+        console.error(msg);
+        process.exit(1);
+        // throw new Error(msg);
+    }
+}
+
 function sortKeysOfDocument(document: Document): Document
 {
     // Create a new object with sorted keys
@@ -139,9 +176,48 @@ function sortKeysOfDocument(document: Document): Document
     return JSON.parse(JSON.stringify(documentCopy)) as Document;
 }
 
-async function testDocumentBatchOperations(firebase: FirebaseWrapper): Promise<void>
+/* TESTS */
+// calls all metadata update functions for a document and checks that the resulting document is correct
+// also checks the share lists of the users that should and should not have access to the document
+async function testDocumentMetadataUpdates(firebase: FirebaseWrapper)
 {
-    const userId = TEST_EMAIL;
-    const owned = await getDocumentsOwnedByUser(userId);
-    console.log(`Owned Documents: ${owned.map((doc) => doc.metadata.document_id).join(',')}`)
+    // create the initial document
+    const SOURCE_DOCUMENT = JSON.parse(JSON.stringify(TEST_DOCUMENT)) as Document;
+    const document = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    const id = document.metadata.document_id;
+    SOURCE_DOCUMENT.metadata.document_id = id;
+    console.log(`Document Id: ${id}`);
+    await updateDocument(SOURCE_DOCUMENT);
+
+    // update the metadata to alternative values
+    await Promise.all([
+        updateDocumentShareStyle(id, SHARE_STYLE.public_document),
+        updateDocumentColor(id, "blue"),
+        updateDocumentEmoji(id, "&#x1f602"),
+        shareDocumentWithUser(id, SECONDARY_TEST_EMAIL),
+        shareDocumentWithUser(id, TERTIARY_TEST_EMAIL),
+    ]);
+    await unshareDocumentWithUser(id, TERTIARY_TEST_EMAIL);
+
+    // update source of truth
+    SOURCE_DOCUMENT.metadata.share_style = SHARE_STYLE.public_document;
+    SOURCE_DOCUMENT.metadata.preview_color = "blue";
+    SOURCE_DOCUMENT.metadata.preview_emoji = "&#x1f602";
+    SOURCE_DOCUMENT.metadata.share_list = [SECONDARY_TEST_EMAIL];
+
+    // grab the stored information
+    const databaseDocument = await getDocument(id);
+    const secondaryUserShares = await getDocumentsSharedWithUser(SECONDARY_TEST_EMAIL);
+    const tertiaryUserShares = await getDocumentsSharedWithUser(TERTIARY_TEST_EMAIL);
+
+    // verification checks
+    assert(isEqual(SOURCE_DOCUMENT, databaseDocument));
+    // the shared document is in the shared list
+    assert(secondaryUserShares.filter((sharedDoc) => 
+        sharedDoc.metadata.document_id === id)
+        .length > 0);
+    // the shared document is not in the shared list
+    assert(tertiaryUserShares.filter((sharedDoc) => 
+        sharedDoc.metadata.document_id === id)
+        .length === 0);
 }


### PR DESCRIPTION
# Summary

Bug fix: the metadata updates to the share list weren't being reflected in the shared user lists in Firestore. I fixed this by adding the appropriate calls to the two metadata update share functions.

# Test Plan

Wrote a more unit test-like function for checking that the metadata update functions correctly impact the database.  Eventually, I want this test to be called automatically before every merge into main.

-----
Please consider the impact of your changes on the other developers.