### PR TITLE
add function to monitor realtime updates for single documents

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,13 +14,13 @@
     "debug": "node --inspect-brk -r module-alias/register -r ts-node/register src/main.ts"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.7",
-    "lodash": "^4.17.21",
     "ts-node": "^10.9.2"
   },
   "dependencies": {
+    "@types/lodash": "^4.17.7",
     "@types/node": "^22.5.4",
     "firebase": "^10.13.0",
+    "lodash": "^4.17.21",
     "module-alias": "^2.2.3",
     "typescript": "^5.5.4"
   }

--- a/backend/src/document-utils/realtimeDocumentUpdates.ts
+++ b/backend/src/document-utils/realtimeDocumentUpdates.ts
@@ -1,0 +1,18 @@
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+import { Document } from "@lib/documentTypes";
+
+// takes in the documentId and a function that is called whenever the document is updated in firebase
+// the onUpdateFn function takes in the updated document and is intended to be used to update the local
+// document version (ie use this updated document)
+export async function subscribeToDocumentUpdates(documentId: string,    
+                                                 onUpdateFn: (updatedDocument: Document) => void)
+{
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+
+    firebase.subscribeToDocument(documentId, (snapshot) => {
+        if(snapshot.exists && snapshot.data() !== null && snapshot.data() !== undefined) {
+            onUpdateFn(snapshot.data() as Document);
+        }
+    });
+}

--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -239,4 +239,12 @@ export default class FirebaseWrapper
                     .doc(userId)
                     .update(updatedObject);
     }
+
+    public async subscribeToDocument(documentId: string, onSnapshotFn: (snapshot: firebase.firestore.DocumentSnapshot) => void) 
+    {
+        firebase.firestore()
+                .collection(DOCUMENT_DATABASE_NAME)
+                .doc(documentId)
+                .onSnapshot( onSnapshotFn);
+    }
 }

--- a/backend/src/tests/testController.ts
+++ b/backend/src/tests/testController.ts
@@ -2,6 +2,7 @@ import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { Document,  Comment, SHARE_STYLE } from '@lib/documentTypes';
 import { createDocument, updateDocument, deleteDocument, getDocument } from '../document-utils/documentOperations';
 import { getDocumentsOwnedByUser, getDocumentsSharedWithUser } from "../document-utils/documentBatchRead";
+import { subscribeToDocumentUpdates } from "../document-utils/realtimeDocumentUpdates";
 import { updateDocumentShareStyle, 
          updateDocumentEmoji, 
          updateDocumentColor, 
@@ -61,6 +62,26 @@ export async function runTest()
     // await testDocumentMetadataUpdate(firebase);
     // testDocumentConversion(firebase);
     process.exit(0);
+}
+
+export async function testDocumentChanges()
+{
+    // create the document
+    const SOURCE_DOCUMENT = JSON.parse(JSON.stringify(TEST_DOCUMENT)) as Document;
+    const document = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    const id = document.metadata.document_id;
+    SOURCE_DOCUMENT.metadata.document_id = id;
+    console.log(`Document Id: ${id}`);
+    await updateDocument(SOURCE_DOCUMENT);
+
+    let currentDocument = SOURCE_DOCUMENT;
+
+    // subscribe to updates
+    subscribeToDocumentUpdates(id, (updatedDocument: Document) => {
+        console.log(`Detected changes in document ${id}`);
+        console.log(`Updated Document: ${JSON.stringify(updatedDocument)}`);
+        currentDocument = updatedDocument;
+    });
 }
 
 async function testSignUp(firebase: FirebaseWrapper)


### PR DESCRIPTION
# Summary

Add a `subscribeToDocumentUpdates`, which takes in the document id of a single document to watch. Every time the document changes (this also includes the first call to the function, since before then the document is considered undefined), an update function is called. This update function is passed in as a parameter to the subscription and takes in a Document. The update function will be called on the newest document in Firebase, whenever there is one, until the process is exited.

# Test Plan

Ran the `testDocumentChanges` function in the `testController.ts` file. This function calls the subscription function. I verified that a change in Firestore was reflected in a console.log statement after running the test function.

-----
Please consider the impact of your changes on the other developers.