### PR TITLE
auth users before reads and writes

### DIFF
--- a/backend/src/document-utils/documentBatchRead.ts
+++ b/backend/src/document-utils/documentBatchRead.ts
@@ -3,34 +3,43 @@ import { getDocument } from "./documentOperations";
 import { Document } from '@lib/documentTypes';
 
 // returns all documents created by the user associated with the userId
-export async function getDocumentsOwnedByUser(userId: string): Promise<Document[]>
+export async function getDocumentsOwnedByUser(userEmail: string): Promise<Document[]>
 {
-    return getDocumentsByUser(userId, true);
+    return getDocumentsByUser(userEmail, true);
 }
 
-// returns all documents shared with the user associated with the userId
+// returns all documents shared with the user associated with the userEmail
 // this function does not distinguish between view-only shares, comment-able shares, or edit shares
-export async function getDocumentsSharedWithUser(userId: string): Promise<Document[]>
+export async function getDocumentsSharedWithUser(userEmail: string): Promise<Document[]>
 {
-    return getDocumentsByUser(userId, false);
+    return getDocumentsByUser(userEmail, false);
 }
 
-async function getDocumentsByUser(userId: string, isOwned: boolean): Promise<Document[]>
+async function getDocumentsByUser(userEmail: string, isOwned: boolean): Promise<Document[]>
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
-    const documentIdList = await getDocumentIdsByUser(userId, isOwned);
+    const documentIdList = await getDocumentIdsByUser(userEmail, isOwned);
     const documentList = [];
     for(const id of documentIdList)
     {
-        documentList.push(await getDocument(id));
+        try {
+            const document = await getDocument(id, userEmail);
+            if(document === null || document === undefined) {
+                continue;
+            }
+            documentList.push(document);
+        } catch(error)
+        {
+            console.warn(`user ${userEmail} trying to access document ${id} but does not have permissions`);
+        }
     }
     return documentList;
 }
 
-async function getDocumentIdsByUser(userId: string, isOwned: boolean): Promise<string[]>
+async function getDocumentIdsByUser(userEmail: string, isOwned: boolean): Promise<string[]>
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
-    return await firebase.getUserDocuments(userId, isOwned);
+    return await firebase.getUserDocuments(userEmail, isOwned);
 }

--- a/backend/src/document-utils/documentOperations.ts
+++ b/backend/src/document-utils/documentOperations.ts
@@ -1,9 +1,12 @@
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { Document, DocumentMetadata, SHARE_STYLE } from '@lib/documentTypes'; 
+import { userHasReadAccess, userHasWriteAccess } from '../security-utils/permissionVerification';
+
+// NOTE: UPDATE MODIFIES the document that is passed to it
 
 // takes in the user id who triggered the document creation and returns a
 // promise containing a default (blank) document as a Document
-export async function createDocument(creatorId: string): Promise<Document>
+export async function createDocument(writerEmail: string): Promise<Document>
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
@@ -12,11 +15,11 @@ export async function createDocument(creatorId: string): Promise<Document>
     const currentTime = Date.now();
     const metadata: DocumentMetadata = {
         document_id: documentId,
-        owner_email: creatorId,
+        owner_email: writerEmail,
         share_style: SHARE_STYLE.private_document,
         time_created: currentTime,
         last_edit_time: currentTime,
-        last_edit_user: creatorId,
+        last_edit_user: writerEmail,
     };
     const document : Document = {
         document_title: "",
@@ -26,27 +29,55 @@ export async function createDocument(creatorId: string): Promise<Document>
     };
 
     await firebase.updateDocument(documentId, document);
-    await firebase.insertUserDocument(creatorId, documentId, true);
+    await firebase.insertUserDocument(writerEmail, documentId, true);
     return document;
 }
 
-// takes in the updated documet and returns a promise containing true iff the document was
-// successfully updated
-// assumes the writing user has already been authenticated
-// ONLY UPDATE THE DOCUMENT CONTENT USING THIS FUNCTION (metadata should be updated in a different function)
-export async function updateDocument(updatedDocument: Document): Promise<boolean>
-{
+// DO NOT CALL THIS FUNCTION
+// processes a document update request
+export async function processDocumentUpdate(
+    documentObject: Record<string, unknown>, 
+    documentId: string, 
+    writerEmail: string
+): Promise<boolean> {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
 
-    const documentId = updatedDocument.metadata.document_id;
-    return firebase.updateDocument(documentId, updatedDocument);
+    // check that the document exists and the user can write to it
+    const initialDocument = await firebase.getDocument(documentId);
+    if(initialDocument === null) {
+        throw Error(`Trying to update document ${documentId}, which doesn't exist in Firestore`);
+    } else if(!userHasWriteAccess(writerEmail, initialDocument)) {
+        throw Error(`User ${writerEmail} is trying to update document ${documentId}, but doesn't have the permissions to do so`);
+    }
+
+    // update the fields that are edited during a write
+    if('metadata' in documentObject)
+    {
+        (documentObject['metadata'] as any)['last_edit_time'] = Date.now();
+        (documentObject['metadata'] as any)['last_edit_user'] = writerEmail;
+    } else
+    {
+        documentObject['metadata.last_edit_time'] = Date.now();
+        documentObject['metadata.last_edit_user'] = writerEmail;
+    }
+
+    // update partial document
+    return firebase.updatePartialDocument(documentId, documentObject);
+}
+
+// takes in the updated document and the email of the user making the edit(s)
+// returns a promise containing true iff the document was successfully updated
+// ONLY UPDATE THE DOCUMENT CONTENT USING THIS FUNCTION (metadata should be updated in a different function)
+export async function updateDocument(updatedDocument: Document, writerEmail: string): Promise<boolean>
+{
+    return processDocumentUpdate(updatedDocument, updatedDocument.metadata.document_id, writerEmail);
 }
 
 // returns a promise containing the Document associated with the documentId
-// assumes proper access has already been verified
-// throws an error if document retrieval failed
-export async function getDocument(documentId: string): Promise<Document>
+// throws an error if document retrieval failed or if the user lacks appropriate permissions
+// readerEmail is the email of the user attempting to get the document
+export async function getDocument(documentId: string, readerEmail: string): Promise<Document>
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
@@ -56,16 +87,26 @@ export async function getDocument(documentId: string): Promise<Document>
     {
         throw Error(`Error retrieving firebase document ${documentId}. Make sure the document associated with the id and the internet connection is good.`)
     }
-
+        
+    if(!userHasReadAccess(readerEmail, firebaseDocument))
+    {
+        throw Error(`User with email ${readerEmail} does not have read access to document with id ${documentId}`);
+    }
     return firebaseDocument;
 }
 
 // deletes the document associated with the given document id
-// assumes the user owns the document
-export async function deleteDocument(document: Document): Promise<void>
+// will only delete the document if it exists and the user that is attempting the delete is the creator
+// writerEmail is the email of the user doing the deletion
+export async function deleteDocument(document: Document, writerEmail: string): Promise<void>
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
+
+    if(writerEmail !== document.metadata.owner_email)
+    {
+        throw Error(`User ${writerEmail} is trying to delete document ${document.metadata.document_id}, which is owned by another user`);
+    }
 
     const documentId = document.metadata.document_id;
     const userId = document.metadata.owner_email;

--- a/backend/src/document-utils/updateDocumentMetadata.ts
+++ b/backend/src/document-utils/updateDocumentMetadata.ts
@@ -1,10 +1,9 @@
-import { Document, DocumentMetadata, SHARE_STYLE } from "@lib/documentTypes";
+import { SHARE_STYLE } from "@lib/documentTypes";
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 
 import firebase from 'firebase/compat/app'
 import 'firebase/compat/firestore';
-
-// TO DO: verify that key passed in to updateDocumentMetadata is valid
+import { processDocumentUpdate } from "./documentOperations";
 
 const getFirebase = (): FirebaseWrapper => {
     const firebase = new FirebaseWrapper();
@@ -12,37 +11,70 @@ const getFirebase = (): FirebaseWrapper => {
     return firebase;
 };
 
+// TO DO: verify that key passed in to updateDocumentMetadata is valid
 // generic version of all following functions; updates a metadata field for a document
-async function updateDocumentMetadata(documentId: string, key: string, newValue: unknown) {
-    const firebase = getFirebase();
+async function updateDocumentMetadata(
+    documentId: string, 
+    key: string, 
+    newValue: unknown, 
+    writerEmail: string
+): Promise<boolean> {
     const firebaseKey = `metadata.${key}`;
-    await firebase.updateDocumentMetadataField(documentId, {[firebaseKey]: newValue});
+    return processDocumentUpdate({[firebaseKey]: newValue}, documentId, writerEmail);
 }
 
-export async function updateDocumentShareStyle(documentId: string, newShareStyle: SHARE_STYLE) {
-    await updateDocumentMetadata(documentId, 'share_style', newShareStyle);
+export async function updateDocumentShareStyle(
+    documentId: string, 
+    newShareStyle: SHARE_STYLE, 
+    writerEmail: string
+) {
+    await updateDocumentMetadata(documentId, 'share_style', newShareStyle, writerEmail);
 }
 
-export async function updateDocumentEmoji(documentId: string, newEmoji: string) {
-    await updateDocumentMetadata(documentId, 'preview_emoji', newEmoji);
+export async function updateDocumentEmoji(
+    documentId: string, 
+    newEmoji: string, 
+    writerEmail: string
+) {
+    await updateDocumentMetadata(documentId, 'preview_emoji', newEmoji, writerEmail);
 }
 
-export async function updateDocumentColor(documentId: string, newColor: string) {
-    await updateDocumentMetadata(documentId, 'preview_color', newColor);
+export async function updateDocumentColor(
+    documentId: string, 
+    newColor: string, 
+    writerEmail: string
+) {
+    await updateDocumentMetadata(documentId, 'preview_color', newColor, writerEmail);
 }
 
 // assumption: only call this function if the user is not already in the share list
 // assumption: only share with existing users
-export async function shareDocumentWithUser(documentId: string, newUser: string) {
-    await Promise.all([
-            updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayUnion(newUser)),
-            getFirebase().insertUserDocument(newUser, documentId, false)
-        ]);
+export async function shareDocumentWithUser(
+    documentId: string, 
+    newUser: string, 
+    writerEmail: string
+) {
+    if(await updateDocumentMetadata(
+        documentId, 
+        'share_list', 
+        firebase.firestore.FieldValue.arrayUnion(newUser),
+        writerEmail)
+    ){
+        await getFirebase().insertUserDocument(newUser, documentId, false)
+    }
 }
 
-export async function unshareDocumentWithUser(documentId: string, oldUser: string) {
-    await Promise.all([
-            updateDocumentMetadata(documentId, 'share_list', firebase.firestore.FieldValue.arrayRemove(oldUser)),
-            getFirebase().deleteUserDocument(oldUser, documentId, false)
-        ]);
+export async function unshareDocumentWithUser(
+    documentId: string, 
+    oldUser: string, 
+    writerEmail: string
+) {
+    if(await updateDocumentMetadata(
+        documentId, 
+        'share_list', 
+        firebase.firestore.FieldValue.arrayRemove(oldUser), 
+        writerEmail)
+    ) {
+            await getFirebase().deleteUserDocument(oldUser, documentId, false)
+    }
 }

--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -104,6 +104,7 @@ export default class FirebaseWrapper
 
     // takes in the new document
     // returns true iff the document exists and the update was successful
+    // UNUSED
     public async updateDocument(documentId: string, document: Document): Promise<boolean>
     {
         if(!await this.doesDocumentExist(documentId))
@@ -117,10 +118,10 @@ export default class FirebaseWrapper
         return true;
     }
 
-    // updates a metadata field for a document
+    // updates somes field in a document
     // throws an error if the document does not exist
-    public async updateDocumentMetadataField(documentId: string, updateObject: Record<string, unknown>)
-        : Promise<void>
+    public async updatePartialDocument(documentId: string, updateObject: Record<string, unknown>)
+        : Promise<boolean>
     {
         if(!await this.doesDocumentExist(documentId))
         {
@@ -131,6 +132,7 @@ export default class FirebaseWrapper
                       .collection(DOCUMENT_DATABASE_NAME)
                       .doc(documentId)
                       .update(updateObject);
+        return true;
     }
 
     // takes in the document unique id and returns the associated document as a JSON object

--- a/backend/src/security-utils/permissionVerification.ts
+++ b/backend/src/security-utils/permissionVerification.ts
@@ -1,25 +1,21 @@
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
-import { DocumentMetadata, SHARE_STYLE } from "@lib/documentTypes";
+import { DocumentMetadata, SHARE_STYLE, Document } from "@lib/documentTypes";
 
 // returns true iff a user has read access
 // takes in the email of a user and the id of the document to check
-async function userHasReadAccess(userId: string, documentId: string)
+export function userHasReadAccess(userId: string, document: Document): boolean
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
 
-    const metadata: DocumentMetadata | null = await firebase.getDocumentMetadata(documentId);
+    const metadata: DocumentMetadata = document.metadata;
     if(metadata === null) {
         return false;
-    }
-
-    if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document)
-    {
+    } else if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document) {
         return true;
     } else if(metadata.share_style === SHARE_STYLE.view_list 
            || metadata.share_style === SHARE_STYLE.comment_list 
-           || metadata.share_style === SHARE_STYLE.edit_list )
-    {
+           || metadata.share_style === SHARE_STYLE.edit_list ) {
         return metadata.share_list?.includes(userId) ?? false;
     }
 
@@ -28,22 +24,18 @@ async function userHasReadAccess(userId: string, documentId: string)
 
 // returns true iff a user has comment access
 // takes in the email of a user and the id of the document to check
-async function userHasCommentAccess(userId: string, documentId: string)
+function userHasCommentAccess(userId: string, document: Document): boolean
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
 
-    const metadata : DocumentMetadata | null = await firebase.getDocumentMetadata(documentId);
+    const metadata: DocumentMetadata = document.metadata;
     if(metadata === null) {
         return false;
-    }
-
-    if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document)
-    {
+    } else if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document) {
         return true;
     } else if(metadata.share_style === SHARE_STYLE.comment_list 
-           || metadata.share_style === SHARE_STYLE.edit_list )
-    {
+           || metadata.share_style === SHARE_STYLE.edit_list ) {
         return metadata.share_list?.includes(userId) ?? false;
     }
 
@@ -52,21 +44,17 @@ async function userHasCommentAccess(userId: string, documentId: string)
 
 // returns true iff a user has edit access
 // takes in the email of a user and the id of the document to check
-async function userHasEditAccess(userId: string, documentId: string)
+export function userHasWriteAccess(userId: string, document: Document): boolean
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
 
-    const metadata : DocumentMetadata | null = await firebase.getDocumentMetadata(documentId);
+    const metadata: DocumentMetadata = document.metadata;
     if(metadata === null) {
         return false;
-    }
-
-    if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document)
-    {
+    } else if(metadata.owner_email === userId || metadata.share_style === SHARE_STYLE.public_document) {
         return true;
-    } else if(metadata.share_style === SHARE_STYLE.edit_list )
-    {
+    } else if(metadata.share_style === SHARE_STYLE.edit_list) {
         return metadata.share_list?.includes(userId) ?? false;
     }
 


### PR DESCRIPTION
# Summary

This PR adds permission checks before a user can read or write to a document.  Before a user can read or write to a document, their email will be checked against the set permissions of the document.

In most cases, a `writerEmail` or `readerEmail` is now a required parameter in the document CRUD operation functions. These variables are for the user that is attempting to perform the read/write.

# Test Plan
Overhauled the `testController.ts` file to work with the updated CRUD functions. I got the `testDocumentMetadataUpdates` working, which tests creations, reads, and updates for documents.

Ran `pnpm install`, `pnpm build`, `pnpm dev`, and `pnpm debug` in the backend folder.


-----
Please consider the impact of your changes on the other developers.