### PR TITLE
extract document previews instead of documents for the user access lists

### DIFF
--- a/backend/src/document-utils/documentBatchRead.ts
+++ b/backend/src/document-utils/documentBatchRead.ts
@@ -1,21 +1,21 @@
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
-import { getDocument } from "./documentOperations";
-import { Document } from '@lib/documentTypes';
+import { getDocumentPreview } from "./documentOperations";
+import { DocumentPreview } from '@lib/documentTypes';
 
 // returns all documents created by the user associated with the userId
-export async function getDocumentsOwnedByUser(userEmail: string): Promise<Document[]>
+export async function getDocumentPreviewsOwnedByUser(userEmail: string): Promise<DocumentPreview[]>
 {
-    return getDocumentsByUser(userEmail, true);
+    return getDocumentPreviewsByUser(userEmail, true);
 }
 
 // returns all documents shared with the user associated with the userEmail
 // this function does not distinguish between view-only shares, comment-able shares, or edit shares
-export async function getDocumentsSharedWithUser(userEmail: string): Promise<Document[]>
+export async function getDocumentPreviewsSharedWithUser(userEmail: string): Promise<DocumentPreview[]>
 {
-    return getDocumentsByUser(userEmail, false);
+    return getDocumentPreviewsByUser(userEmail, false);
 }
 
-async function getDocumentsByUser(userEmail: string, isOwned: boolean): Promise<Document[]>
+async function getDocumentPreviewsByUser(userEmail: string, isOwned: boolean): Promise<DocumentPreview[]>
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
@@ -24,7 +24,7 @@ async function getDocumentsByUser(userEmail: string, isOwned: boolean): Promise<
     for(const id of documentIdList)
     {
         try {
-            const document = await getDocument(id, userEmail);
+            const document = await getDocumentPreview(id, userEmail);
             if(document === null || document === undefined) {
                 continue;
             }

--- a/backend/src/document-utils/documentOperations.ts
+++ b/backend/src/document-utils/documentOperations.ts
@@ -1,5 +1,5 @@
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
-import { Document, DocumentMetadata, SHARE_STYLE } from '@lib/documentTypes'; 
+import { Document, DocumentMetadata, DocumentPreview, SHARE_STYLE } from '@lib/documentTypes'; 
 import { userHasReadAccess, userHasWriteAccess } from '../security-utils/permissionVerification';
 
 // NOTE: UPDATE MODIFIES the document that is passed to it
@@ -93,6 +93,16 @@ export async function getDocument(documentId: string, readerEmail: string): Prom
         throw Error(`User with email ${readerEmail} does not have read access to document with id ${documentId}`);
     }
     return firebaseDocument;
+}
+
+// gets a Document and extracts and returns its DocumentPreview
+export async function getDocumentPreview(documentId: string, readerEmail: string): Promise<DocumentPreview>
+{
+    const document = await getDocument(documentId, readerEmail);
+    return {
+        ...document.metadata, 
+        ...{document_title: document.document_title}
+    };
 }
 
 // deletes the document associated with the given document id

--- a/backend/src/tests/testController.ts
+++ b/backend/src/tests/testController.ts
@@ -1,13 +1,15 @@
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { Document,  SHARE_STYLE } from '@lib/documentTypes';
 import { createDocument, updateDocument, deleteDocument, getDocument } from '../document-utils/documentOperations';
-import { getDocumentsOwnedByUser, getDocumentsSharedWithUser } from "../document-utils/documentBatchRead";
+import { getDocumentPreviewsOwnedByUser, getDocumentPreviewsSharedWithUser } from "../document-utils/documentBatchRead";
 import { subscribeToDocumentUpdates } from "../document-utils/realtimeDocumentUpdates";
-import { updateDocumentShareStyle, 
-         updateDocumentEmoji, 
-         updateDocumentColor, 
-         shareDocumentWithUser, 
-         unshareDocumentWithUser } from '../document-utils/updateDocumentMetadata';
+import { 
+    updateDocumentShareStyle,       
+    updateDocumentEmoji, 
+    updateDocumentColor, 
+    shareDocumentWithUser, 
+    unshareDocumentWithUser 
+} from '../document-utils/updateDocumentMetadata';
 
 import { isEqual } from 'lodash';
 
@@ -179,8 +181,8 @@ async function testDocumentMetadataUpdates(firebase: FirebaseWrapper)
 
     // grab the stored information
     const databaseDocument = await getDocument(id, PRIMARY_TEST_EMAIL);
-    const secondaryUserShares = await getDocumentsSharedWithUser(SECONDARY_TEST_EMAIL);
-    const tertiaryUserShares = await getDocumentsSharedWithUser(TERTIARY_TEST_EMAIL);
+    const secondaryUserShares = await getDocumentPreviewsSharedWithUser(SECONDARY_TEST_EMAIL);
+    const tertiaryUserShares = await getDocumentPreviewsSharedWithUser(TERTIARY_TEST_EMAIL);
 
     // verification checks
     SOURCE_DOCUMENT.metadata.last_edit_time = databaseDocument.metadata.last_edit_time;
@@ -188,10 +190,10 @@ async function testDocumentMetadataUpdates(firebase: FirebaseWrapper)
     assert(isEqual(SOURCE_DOCUMENT, databaseDocument));
     // the shared document is in the shared list
     assert(secondaryUserShares.filter((sharedDoc) => 
-        sharedDoc.metadata.document_id === id)
+        sharedDoc.document_id === id)
         .length > 0);
     // the shared document is not in the shared list
     assert(tertiaryUserShares.filter((sharedDoc) => 
-        sharedDoc.metadata.document_id === id)
+        sharedDoc.document_id === id)
         .length === 0);
 }

--- a/lib/documentTypes.ts
+++ b/lib/documentTypes.ts
@@ -43,3 +43,5 @@ export type Comment =
     last_edit_time: number,
 };
 
+// purpose: the preview information of a document for use on a user's storage page
+export type DocumentPreview = DocumentMetadata & {document_title: string};


### PR DESCRIPTION
# Summary

Instead of giving the storage page (name TBD) a list of documents, this PR instead updates the functions to now return a list of DocumentPreviews (definition in the `documentTypes.ts` file).  The DocumentPreview type contains all metadata fields plus the document_title field.

# Test Plan

Updated and ran the `testDocumentMetadataUpdates` function in the `testController.ts` file, and verified that the list of shared documents with the secondary and tertiary user emails were formatted correctly.

-----
Please consider the impact of your changes on the other developers.