### PR TITLE
register users as "on" documents

### DIFF
--- a/backend/src/document-utils/realtimeDocumentUpdates.ts
+++ b/backend/src/document-utils/realtimeDocumentUpdates.ts
@@ -1,3 +1,4 @@
+import { UserEntity } from "@lib/UserEntity";
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { Document } from "@lib/documentTypes";
 
@@ -20,4 +21,20 @@ export async function subscribeToDocumentUpdates(
       onUpdateFn(snapshot.data() as Document);
     }
   });
+}
+
+export async function registerUserToDocument(
+    documentId: string, 
+    user: {user_email: string, user_id: string, display_name: string}
+){
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+
+    // check if document exists (TO DO: remove the need for this check)
+    if(!firebase.doesDocumentExist(documentId))
+    {
+        throw Error(`Trying to register user ${user.user_email} to nonexistant document ${documentId}`);
+    }
+
+    await firebase.registerUserToDocument(documentId, user);
 }

--- a/backend/src/firebaseSecrets.ts
+++ b/backend/src/firebaseSecrets.ts
@@ -11,4 +11,4 @@ export const FIREBASE_CONFIG = {
 
 export const DOCUMENT_DATABASE_NAME = "Composition_Documents";
 export const USER_DATABASE_NAME = "Users_Collection";
-  
+export const ONLINE_TRACKING_DATABASE_NAME = "Online_Tracking_Collection";

--- a/backend/src/tests/testController.ts
+++ b/backend/src/tests/testController.ts
@@ -2,7 +2,7 @@ import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { Document,  SHARE_STYLE } from '@lib/documentTypes';
 import { createDocument, updateDocument, deleteDocument, getDocument } from '../document-utils/documentOperations';
 import { getDocumentPreviewsOwnedByUser, getDocumentPreviewsSharedWithUser } from "../document-utils/documentBatchRead";
-import { subscribeToDocumentUpdates } from "../document-utils/realtimeDocumentUpdates";
+import { registerUserToDocument, subscribeToDocumentUpdates } from "../document-utils/realtimeDocumentUpdates";
 import { 
     updateDocumentShareStyle,       
     updateDocumentEmoji, 
@@ -53,14 +53,21 @@ export async function runTest()
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
-    await testDocumentMetadataUpdates(firebase);
 
+    // await runAllUnitTests(firebase);
+    registerUserToDocument("2R6buaMylmCuus32I0vp", {user_email: PRIMARY_TEST_EMAIL, user_id: "testing_id_1", display_name: "USER 1"});
+    
     // await testSignUp(firebase);
     // await testDocumentDeletion(firebase);
     // await testDocumentUpdate(firebase);
-
+    
     console.log(`Tests completed successfully`);
-    process.exit(0);
+    // process.exit(0);
+}
+
+async function runAllUnitTests(firebase: FirebaseWrapper)
+{
+    await testDocumentMetadataUpdates(firebase);
 }
 
 export async function testDocumentChanges()

--- a/lib/UserEntity.ts
+++ b/lib/UserEntity.ts
@@ -1,8 +1,7 @@
-/*
-    the UserEntity is the type that describes a user account
-*/
+//the UserEntity is the collection of information associated with a user account
 export type UserEntity =
 {
+    user_id: string,                    // the id of the user (Firebase makes one for each registered user)
     user_email: string,                 // the email associated with this user account
     display_name: string,               // the display name for this user
     account_creation_time: number,      // the time (in milliseconds) when this account was created
@@ -10,11 +9,20 @@ export type UserEntity =
     shared_documents: string[],         // a list of the document ids associated with all documents that have been shared with this user
 };
 
+// Purpose: the data associated with an "online" user (a user subscribed to a document)
+export type OnlineEntity = 
+{
+    user_email: string,
+    display_name: string,
+    last_edit_time: number,
+};
+
 // purpose: returns the default user (ie a blank user) for use in account creation
 // this helps populate the database with the default user information 
 export function getDefaultUser(): UserEntity
 {
     return {
+        user_id: "",
         user_email: "",
         display_name: "",
         owned_documents: [],


### PR DESCRIPTION
# Summary
Using the Realtime Database (as opposed to Firestore), you can now register a user to a document. This will allow other users to "see" who's online.  Right now, you can only add an entry of a user to a subscribed document, and the entry deletes itself when the user disconnects from Firebase.  Later, I will tie this more closely to document subscriptions, so that these entries can be updated and trigger local changes.

# Test Plan
Ran the new function and checked that the Realtime Database added and then deleted the user entry.

-----
Please consider the impact of your changes on the other developers.