### PR TITLE
subscribe to user pool (online users) updates

### DIFF
--- a/backend/src/tests/testController.ts
+++ b/backend/src/tests/testController.ts
@@ -3,7 +3,7 @@ import { Document,  SHARE_STYLE } from '@lib/documentTypes';
 import { createDocument, updateDocument, deleteDocument, getDocument } from '../document-utils/documentOperations';
 import { getDocumentPreviewsOwnedByUser, getDocumentPreviewsSharedWithUser } from "../document-utils/documentBatchRead";
 import { subscribeToDocumentUpdates } from "../document-utils/realtimeDocumentUpdates";
-import { recordOnlineUserUpdatedDocument, registerUserToDocument, updateUserCursor } from "../document-utils/realtimeOnlineUsers";
+import { recordOnlineUserUpdatedDocument, subscribeUserToUserDocumentPool, updateUserCursor } from "../document-utils/realtimeOnlineUsers";
 import { 
     updateDocumentShareStyle,       
     updateDocumentEmoji, 
@@ -13,6 +13,7 @@ import {
 } from '../document-utils/updateDocumentMetadata';
 
 import { isEqual } from 'lodash';
+import { OnlineEntity, UpdateType } from "@lib/userTypes";
 
 const PRIMARY_TEST_EMAIL = "test-user-1@tune-tracer.com";
 const TEST_PASSWORD = "This*Is*A*Strong*Password100!";
@@ -139,10 +140,12 @@ async function testUserRegistrationToDocument(firebase: FirebaseWrapper) {
         display_name: "ADMIN_TEST"
     };
     
-    await registerUserToDocument(documentId, userEntity);
+    await subscribeUserToUserDocumentPool(documentId, userEntity, (updateType: UpdateType, onlineEntity: OnlineEntity) =>
+    {
+        console.log(`Update ${updateType} with entity=${JSON.stringify(onlineEntity)}`);
+    });
     await recordOnlineUserUpdatedDocument(documentId, {user_id: userId});
     await updateUserCursor(documentId, {user_id: userId, cursor: "right here"});
-    console.log(`User cursor has moved; check Realtime DB`);
 }
 
 /*

--- a/lib/userTypes.ts
+++ b/lib/userTypes.ts
@@ -19,6 +19,13 @@ export type OnlineEntity =
     cursor?: unknown,                   // what the user is editing, highlighting, or has clicked
 };
 
+// Purpose: for defining the kind of update that an OnlineEntity can experience during an online user subscription
+export enum UpdateType {
+    ADD = 1,                            // the OnlineEntity was added to the pool of online users
+    CHANGE = 2,                         // the data in an OnlineEntity was changed
+    DELETE = 3,                         // the OnlineEntity was deleted from the pool of online users
+};
+
 // purpose: returns the default user (ie a blank user) for use in account creation
 // this helps populate the database with the default user information 
 export function getDefaultUser(): UserEntity


### PR DESCRIPTION
# Summary

Add the subscribe to user pool function, so that the frontend can update the existing OnlineEntity objects for a document.

# Test Plan

Ran the `testUserRegistrationToDocument` in the `testController.ts` file. 

-----
Please consider the impact of your changes on the other developers.