### PR TITLE
tie document subscription with user pool subscription together

### DIFF
--- a/backend/src/document-utils/realtimeDocumentUpdates.ts
+++ b/backend/src/document-utils/realtimeDocumentUpdates.ts
@@ -1,15 +1,30 @@
+import { OnlineEntity, UpdateType, UserEntity } from "@lib/userTypes";
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { Document } from "@lib/documentTypes";
+import { subscribeUserToUserDocumentPool } from "./realtimeOnlineUsers";
 
-// takes in the documentId and a function that is called whenever the document is updated in firebase
-// the onUpdateFn function takes in the updated document and is intended to be used to update the local
-// document version (ie use this updated document)
-export async function subscribeToDocumentUpdates(
+/**
+ * Subscribes the user to a document. Adds the user to the user pool and calls the onDocumentUpdateFn and onUserPoolUpdateFn
+ * whenever updates occur.  Both callback functions will be triggered on first call to the subscribeToDocument function will
+ * the initial information.
+ * @param documentId the id of the document that the user is subscribing to
+ * @param user the user account information (the user_id, user_email, and display_name fields are required, others are optional)
+ * @param onDocumentUpdateFn the callback function that is called everytime the document is updated (locally or remotely).
+ *  updatedDocument is the document that has been updated. 
+ *  Race conditions possible, make sure to verify that the updated version is newer.
+ * @param onUserPoolUpdateFn the callback function that is called everytime the user pool is updated (locally or remotely).
+ *  Is called on the type of update and the updated OnlineEntity. Race conditions possible, make sure last_active_time is more recent
+ */
+export async function subscribeToDocument(
   documentId: string,
-  onUpdateFn: (updatedDocument: Document) => void
+  user: Record<string, unknown> & Required<Pick<UserEntity, 'user_id' | 'user_email' | 'display_name'>>,
+  onDocumentUpdateFn: (updatedDocument: Document) => void,
+  onUserPoolUpdateFn: (updateType: UpdateType, updatedUser: OnlineEntity) => void,
 ) {
   const firebase = new FirebaseWrapper();
   firebase.initApp();
+
+  await subscribeUserToUserDocumentPool(documentId, user, onUserPoolUpdateFn);
 
   firebase.subscribeToDocument(documentId, (snapshot) => {
     if (
@@ -17,7 +32,7 @@ export async function subscribeToDocumentUpdates(
       snapshot.data() !== null &&
       snapshot.data() !== undefined
     ) {
-      onUpdateFn(snapshot.data() as Document);
+      onDocumentUpdateFn(snapshot.data() as Document);
     }
   });
 }

--- a/backend/src/user-utils/getUserData.ts
+++ b/backend/src/user-utils/getUserData.ts
@@ -1,0 +1,25 @@
+// this is a temporary file to get user information
+
+import { UserEntity } from "@lib/userTypes";
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+
+// I will eventually convert everything to use firebase's auth instead of direct emails
+
+async function getUser(userEmail: string): Promise<UserEntity | null>
+{
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+    return firebase.getUser(userEmail);
+}
+
+export async function getUserIdFromEmail(userEmail: string): Promise<string>
+{
+    const user = await getUser(userEmail);
+
+    if(user === null)
+    {
+        throw Error(`Trying to get id for user ${userEmail}, but could not find user in database`);
+    }
+
+    return user.user_id;
+}


### PR DESCRIPTION
# Summary

This PR binds the subscribe to document changes with the subscribe to user pool changes functions. Essentially, only 1 API will need to be created to subscribe to a document, instead of two.

# Test Plan

Ran the `testDocumentChanges` function in the `testController` file.  It calls the subscribe to document function and then triggers a couple of changes. I monitored the console to verify that the output was expected.

-----
Please consider the impact of your changes on the other developers.