### PR TITLE
use user ids for everything instead of user emails

### DIFF
--- a/backend/src/document-utils/documentBatchRead.ts
+++ b/backend/src/document-utils/documentBatchRead.ts
@@ -2,38 +2,38 @@ import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { getDocumentPreview } from "./documentOperations";
 import { DocumentPreview } from '@lib/documentTypes';
 
-// returns all documents created by the user associated with the userEmail
-export async function getDocumentPreviewsOwnedByUser(userEmail: string): Promise<DocumentPreview[]>
+// returns all documents created by the user associated with the userId
+export async function getDocumentPreviewsOwnedByUser(userId: string): Promise<DocumentPreview[]>
 {
-    return getDocumentPreviewsByUser(userEmail, true);
+    return getDocumentPreviewsByUser(userId, true);
 }
 
-// returns all documents shared with the user associated with the userEmail
+// returns all documents shared with the user associated with the userId
 // this function does not distinguish between view-only shares, comment-able shares, or edit shares
-export async function getDocumentPreviewsSharedWithUser(userEmail: string): Promise<DocumentPreview[]>
+export async function getDocumentPreviewsSharedWithUser(userId: string): Promise<DocumentPreview[]>
 {
-    return getDocumentPreviewsByUser(userEmail, false);
+    return getDocumentPreviewsByUser(userId, false);
 }
 
-// returns a list of DocumentPreviews that the user associated with the userEmail 
+// returns a list of DocumentPreviews that the user associated with the userId 
 // owns (if isOwned is true) or is shared with the user (if isOwned is false)
-async function getDocumentPreviewsByUser(userEmail: string, isOwned: boolean): Promise<DocumentPreview[]>
+async function getDocumentPreviewsByUser(userId: string, isOwned: boolean): Promise<DocumentPreview[]>
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
-    const documentIdList = await getDocumentIdsByUser(userEmail, isOwned);
+    const documentIdList = await getDocumentIdsByUser(userId, isOwned);
     const documentList = [];
     for(const id of documentIdList)
     {
         try {
-            const document = await getDocumentPreview(id, userEmail);
+            const document = await getDocumentPreview(id, userId);
             if(document === null || document === undefined) {
                 continue;
             }
             documentList.push(document);
         } catch(error)
         {
-            console.warn(`user ${userEmail} trying to access document ${id} but does not have permissions`);
+            console.warn(`user ${userId} trying to access document ${id} but does not have permissions`);
         }
     }
     return documentList;
@@ -41,9 +41,9 @@ async function getDocumentPreviewsByUser(userEmail: string, isOwned: boolean): P
 
 // returns the list of document ids that is in the user's owned list (if isOwned is true) 
 // or shared with list (if isOwned is false)
-async function getDocumentIdsByUser(userEmail: string, isOwned: boolean): Promise<string[]>
+async function getDocumentIdsByUser(userId: string, isOwned: boolean): Promise<string[]>
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
-    return await firebase.getUserDocuments(userEmail, isOwned);
+    return await firebase.getUserDocuments(userId, isOwned);
 }

--- a/backend/src/document-utils/documentOperations.ts
+++ b/backend/src/document-utils/documentOperations.ts
@@ -8,7 +8,7 @@ import { recordOnlineUserUpdatedDocument } from "./realtimeOnlineUsers";
 
 // takes in the user id who triggered the document creation and returns a
 // promise containing a default (blank) document as a Document
-export async function createDocument(writerEmail: string): Promise<Document>
+export async function createDocument(writerId: string): Promise<Document>
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
@@ -17,11 +17,11 @@ export async function createDocument(writerEmail: string): Promise<Document>
     const currentTime = Date.now();
     const metadata: DocumentMetadata = {
         document_id: documentId,
-        owner_email: writerEmail,
+        owner_id: writerId,
         share_style: SHARE_STYLE.private_document,
         time_created: currentTime,
         last_edit_time: currentTime,
-        last_edit_user: writerEmail,
+        last_edit_user: writerId,
     };
     const document : Document = {
         document_title: "",
@@ -31,7 +31,7 @@ export async function createDocument(writerEmail: string): Promise<Document>
     };
 
     await firebase.updateDocument(documentId, document);
-    await firebase.insertUserDocument(writerEmail, documentId, true);
+    await firebase.insertUserDocument(writerId, documentId, true);
     return document;
 }
 
@@ -40,7 +40,7 @@ export async function createDocument(writerEmail: string): Promise<Document>
 export async function processDocumentUpdate(
     documentObject: Record<string, unknown>, 
     documentId: string, 
-    writerEmail: string
+    writerId: string
 ): Promise<boolean> {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
@@ -49,41 +49,39 @@ export async function processDocumentUpdate(
     const initialDocument = await firebase.getDocument(documentId);
     if(initialDocument === null) {
         throw Error(`Trying to update document ${documentId}, which doesn't exist in Firestore`);
-    } else if(!userHasWriteAccess(writerEmail, initialDocument)) {
-        throw Error(`User ${writerEmail} is trying to update document ${documentId}, but doesn't have the permissions to do so`);
+    } else if(!userHasWriteAccess(writerId, initialDocument)) {
+        throw Error(`User ${writerId} is trying to update document ${documentId}, but doesn't have the permissions to do so`);
     }
-
-    const userId = await getUserIdFromEmail(writerEmail);
 
     // update the fields that are edited during a write
     if('metadata' in documentObject)
     {
         (documentObject['metadata'] as any)['last_edit_time'] = Date.now();
-        (documentObject['metadata'] as any)['last_edit_user'] = writerEmail;
+        (documentObject['metadata'] as any)['last_edit_user'] = writerId;
     } else
     {
         documentObject['metadata.last_edit_time'] = Date.now();
-        documentObject['metadata.last_edit_user'] = writerEmail;
+        documentObject['metadata.last_edit_user'] = writerId;
     }
 
     // update partial document
-    await recordOnlineUserUpdatedDocument(documentId, {user_id: userId});
+    await recordOnlineUserUpdatedDocument(documentId, {user_id: writerId});
     return firebase.updatePartialDocument(documentId, documentObject);
 }
 
-// takes in the updated document and the email of the user making the edit(s)
+// takes in the updated document and the id of the user making the edit(s)
 // returns a promise containing true iff the document was successfully updated
 // ONLY UPDATE THE DOCUMENT CONTENT USING THIS FUNCTION (metadata should be updated in a different function)
-export async function updateDocument(updatedDocument: Document, writerEmail: string): Promise<boolean>
+export async function updateDocument(updatedDocument: Document, writerId: string): Promise<boolean>
 {
-    return processDocumentUpdate(updatedDocument, updatedDocument.metadata.document_id, writerEmail);
+    return processDocumentUpdate(updatedDocument, updatedDocument.metadata.document_id, writerId);
 }
 
 // DO NOT DIRECTLY CALL THIS FUNCTION IN THE APIs
 // returns a promise containing the Document associated with the documentId
 // throws an error if document retrieval failed or if the user lacks appropriate permissions
-// readerEmail is the email of the user attempting to get the document
-export async function getDocument(documentId: string, readerEmail: string): Promise<Document>
+// readerId is the user id of the user attempting to get the document
+export async function getDocument(documentId: string, readerId: string): Promise<Document>
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
@@ -94,17 +92,17 @@ export async function getDocument(documentId: string, readerEmail: string): Prom
         throw Error(`Error retrieving firebase document ${documentId}. Make sure the document associated with the id and the internet connection is good.`)
     }
         
-    if(!userHasReadAccess(readerEmail, firebaseDocument))
+    if(!userHasReadAccess(readerId, firebaseDocument))
     {
-        throw Error(`User with email ${readerEmail} does not have read access to document with id ${documentId}`);
+        throw Error(`User with id ${readerId} does not have read access to document with id ${documentId}`);
     }
     return firebaseDocument;
 }
 
 // gets a Document and extracts and returns its DocumentPreview
-export async function getDocumentPreview(documentId: string, readerEmail: string): Promise<DocumentPreview>
+export async function getDocumentPreview(documentId: string, readerId: string): Promise<DocumentPreview>
 {
-    const document = await getDocument(documentId, readerEmail);
+    const document = await getDocument(documentId, readerId);
     return {
         ...document.metadata, 
         ...{document_title: document.document_title}
@@ -113,19 +111,19 @@ export async function getDocumentPreview(documentId: string, readerEmail: string
 
 // deletes the document associated with the given document id
 // will only delete the document if it exists and the user that is attempting the delete is the creator
-// writerEmail is the email of the user doing the deletion
-export async function deleteDocument(document: Document, writerEmail: string): Promise<void>
+// writerId is the user id of the user doing the deletion
+export async function deleteDocument(document: Document, writerId: string): Promise<void>
 {
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
 
-    if(writerEmail !== document.metadata.owner_email)
+    if(writerId !== document.metadata.owner_id)
     {
-        throw Error(`User ${writerEmail} is trying to delete document ${document.metadata.document_id}, which is owned by another user`);
+        throw Error(`User ${writerId} is trying to delete document ${document.metadata.document_id}, which is owned by another user`);
     }
 
     const documentId = document.metadata.document_id;
-    const userId = document.metadata.owner_email;
+    const userId = document.metadata.owner_id;
 
     await firebase.deleteDocument(documentId);
     

--- a/backend/src/document-utils/realtimeOnlineUsers.ts
+++ b/backend/src/document-utils/realtimeOnlineUsers.ts
@@ -50,8 +50,7 @@ export async function recordOnlineUserUpdatedDocument(
 /**
  * Records a new cursor placement for a user on a document.
  * @param documentId the unique id of the document that the user is on
- * @param onlineUser a user object containing '
- *      the user id (not email) associated with the email and the current cursor information for the user.
+ * @param onlineUser a user object containing the user id and the current cursor information for the user.
  */
 export async function updateUserCursor(
     documentId: string, 

--- a/backend/src/document-utils/updateDocumentMetadata.ts
+++ b/backend/src/document-utils/updateDocumentMetadata.ts
@@ -9,39 +9,39 @@ import "firebase/compat/firestore";
 export async function updateDocumentShareStyle(
   documentId: string,
   newShareStyle: SHARE_STYLE,
-  writerEmail: string
+  writerId: string
 ) {
   await updateDocumentMetadata(
     documentId,
     "share_style",
     newShareStyle,
-    writerEmail
+    writerId
   );
 }
 
 export async function updateDocumentEmoji(
   documentId: string,
   newEmoji: string,
-  writerEmail: string
+  writerId: string
 ) {
   await updateDocumentMetadata(
     documentId,
     "preview_emoji",
     newEmoji,
-    writerEmail
+    writerId
   );
 }
 
 export async function updateDocumentColor(
   documentId: string,
   newColor: string,
-  writerEmail: string
+  writerId: string
 ) {
   await updateDocumentMetadata(
     documentId,
     "preview_color",
     newColor,
-    writerEmail
+    writerId
   );
 }
 
@@ -50,14 +50,14 @@ export async function updateDocumentColor(
 export async function shareDocumentWithUser(
   documentId: string,
   newUser: string,
-  writerEmail: string
+  writerId: string
 ) {
   if (
     await updateDocumentMetadata(
       documentId,
       "share_list",
       firebase.firestore.FieldValue.arrayUnion(newUser),
-      writerEmail
+      writerId
     )
   ) {
     await getFirebase().insertUserDocument(newUser, documentId, false);
@@ -67,14 +67,14 @@ export async function shareDocumentWithUser(
 export async function unshareDocumentWithUser(
   documentId: string,
   oldUser: string,
-  writerEmail: string
+  writerId: string
 ) {
   if (
     await updateDocumentMetadata(
       documentId,
       "share_list",
       firebase.firestore.FieldValue.arrayRemove(oldUser),
-      writerEmail
+      writerId
     )
   ) {
     await getFirebase().deleteUserDocument(oldUser, documentId, false);
@@ -87,13 +87,13 @@ async function updateDocumentMetadata(
   documentId: string,
   key: string,
   newValue: unknown,
-  writerEmail: string
+  writerId: string
 ): Promise<boolean> {
   const firebaseKey = `metadata.${key}`;
   return processDocumentUpdate(
     { [firebaseKey]: newValue },
     documentId,
-    writerEmail
+    writerId
   );
 }
 

--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -49,10 +49,7 @@ export default class FirebaseWrapper
             userEntity.display_name = displayName;
             userEntity.user_id = user.uid;
 
-            await firebase.firestore()
-                          .collection(USER_DATABASE_NAME)
-                          .doc(email)
-                          .set(userEntity);
+            await this.setUser(userEntity);
 
         } catch(error) {
             // if the account creation failed, make sure to remove all updates made to Firestore
@@ -192,18 +189,26 @@ export default class FirebaseWrapper
         await firebase.firestore().collection(DOCUMENT_DATABASE_NAME).doc(documentId).delete();
     }
 
-    public async getUser(userEmail: string): Promise<UserEntity> {
+    public async getUser(userId: string): Promise<UserEntity> {
         const collection = (await firebase.firestore()
             .collection(USER_DATABASE_NAME)
-            .doc(userEmail)
+            .doc(userId)
             .get());
         
         if(!collection.exists)
         {
-            throw Error(`Could not find ${userEmail} in database`);
+            throw Error(`Could not find user ${userId} in database`);
         } 
 
         return collection.data() as UserEntity;
+    }
+
+    public async setUser(userEntity: UserEntity)
+    {
+        await firebase.firestore()
+                .collection(USER_DATABASE_NAME)
+                .doc(userEntity.user_id)
+                .set(userEntity);
     }
     // gets the list of document ids of documents owned (if isOwned is true) or shared (is isOwned is false)
     // by a particular user

--- a/backend/src/scripts/refreshFirestoreUserAccessLists.ts
+++ b/backend/src/scripts/refreshFirestoreUserAccessLists.ts
@@ -16,14 +16,14 @@ export async function refreshFirestoreUserAccessLists()
     const shared = new Map<string, string[]>();
     const owned = new Map<string, string[]>();
 
-    const updateMap = (email: string, map: Map<string, string[]>, documentId: string) =>
+    const updateMap = (userId: string, map: Map<string, string[]>, documentId: string) =>
     {
-        if(!map.has(email))
+        if(!map.has(userId))
         {
-            map.set(email, []);
+            map.set(userId, []);
         }
 
-        map.get(email)?.push(documentId);
+        map.get(userId)?.push(documentId);
     };
 
     // get all documents
@@ -42,7 +42,7 @@ export async function refreshFirestoreUserAccessLists()
             return;
         }
         const metadata = data['metadata'] as DocumentMetadata;
-        if(!('document_id' in metadata && 'owner_email' in metadata))
+        if(!('document_id' in metadata && 'owner_id' in metadata))
         {
             console.warn(`Skipping document ${snapshot.id} because missing required metadata fields`);
             return;
@@ -52,7 +52,7 @@ export async function refreshFirestoreUserAccessLists()
             console.log(`Updating document ${snapshot.id} id because recorded metadata id is ${metadata.document_id}`);
             batch.update(snapshot.ref, {'metadata.document_id': snapshot.id});
         }
-        const owner = metadata.owner_email;
+        const owner = metadata.owner_id;
         let shares: string[] = [];
         if(
             metadata.share_style === SHARE_STYLE.comment_list || 
@@ -63,7 +63,7 @@ export async function refreshFirestoreUserAccessLists()
         }
 
         updateMap(owner, owned, snapshot.id);
-        shares.forEach((email: string) => updateMap(email, shared, snapshot.id));
+        shares.forEach((userId: string) => updateMap(userId, shared, snapshot.id));
     }));
 
     const compareLists = (a: string[], b: string[]): boolean =>

--- a/backend/src/security-utils/permissionVerification.ts
+++ b/backend/src/security-utils/permissionVerification.ts
@@ -11,7 +11,7 @@ export function userHasReadAccess(userId: string, document: Document): boolean {
   if (metadata === null) {
     return false;
   } else if (
-    metadata.owner_email === userId ||
+    metadata.owner_id === userId ||
     metadata.share_style === SHARE_STYLE.public_document
   ) {
     return true;
@@ -36,7 +36,7 @@ function userHasCommentAccess(userId: string, document: Document): boolean {
   if (metadata === null) {
     return false;
   } else if (
-    metadata.owner_email === userId ||
+    metadata.owner_id === userId ||
     metadata.share_style === SHARE_STYLE.public_document
   ) {
     return true;
@@ -63,7 +63,7 @@ export function userHasWriteAccess(
   if (metadata === null) {
     return false;
   } else if (
-    metadata.owner_email === userId ||
+    metadata.owner_id === userId ||
     metadata.share_style === SHARE_STYLE.public_document
   ) {
     return true;

--- a/backend/src/tests/testController.ts
+++ b/backend/src/tests/testController.ts
@@ -17,9 +17,10 @@ import { OnlineEntity, UpdateType } from "@lib/userTypes";
 import { getUserIdFromEmail } from "../user-utils/getUserData";
 
 const PRIMARY_TEST_EMAIL = "test-user-1@tune-tracer.com";
+const PRIMARY_TEST_ID = "OgGilSJwqCW3qMuHWlChEYka9js1";
 const TEST_PASSWORD = "This*Is*A*Strong*Password100!";
-const SECONDARY_TEST_EMAIL = "test-user-2@tune-tracer.com";
-const TERTIARY_TEST_EMAIL = "test-user-3@tune-tracer.com";
+const SECONDARY_TEST_ID = "d0zM0dYlUdTR1qf7QFOLQWPQ5qA2";
+const TERTIARY_TEST_ID = "1HyvutGfMdaQmaU2ASTIBP8h4HT2";
 
 // to test: 
 // check sign up correctly add user in user collection
@@ -35,7 +36,7 @@ const TEST_DOCUMENT: Document = {
         {
             comment_id: "1234",
             content: "help me I'm a comment",
-            author_email: PRIMARY_TEST_EMAIL,
+            author_id: PRIMARY_TEST_ID,
             is_reply: false,
             time_created: 1234556,
             last_edit_time: 1234556,
@@ -43,11 +44,11 @@ const TEST_DOCUMENT: Document = {
     ],
     metadata: {
         document_id: "test_document_id",
-        owner_email: PRIMARY_TEST_EMAIL,
+        owner_id: PRIMARY_TEST_ID,
         share_style: 1,
         time_created: 0,
         last_edit_time: 12,
-        last_edit_user: PRIMARY_TEST_EMAIL,
+        last_edit_user: PRIMARY_TEST_ID,
     },
     document_title: "Document Title",
 };
@@ -57,9 +58,9 @@ export async function runTest()
     const firebase: FirebaseWrapper = new FirebaseWrapper();
     firebase.initApp();
 
-    // await runAllUnitTests(firebase);
+    await runAllUnitTests(firebase);
 
-    await testDocumentChanges();
+    // await testDocumentChanges();
     // await testUserRegistrationToDocument(firebase);
     // await testSignUp(firebase);
     // await testDocumentDeletion(firebase);
@@ -78,13 +79,13 @@ export async function testDocumentChanges()
 {
     // create the document
     const SOURCE_DOCUMENT = JSON.parse(JSON.stringify(TEST_DOCUMENT)) as Document;
-    const document = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    const document = await createDocument(TEST_DOCUMENT.metadata.owner_id);
     const id = document.metadata.document_id;
     SOURCE_DOCUMENT.metadata.document_id = id;
     console.log(`Document Id: ${id}`);
     
     let currentDocument = SOURCE_DOCUMENT;
-    const user_id = await getUserIdFromEmail(PRIMARY_TEST_EMAIL);
+    const user_id = await getUserIdFromEmail(PRIMARY_TEST_ID);
     const user = {
         user_email: PRIMARY_TEST_EMAIL,
         user_id: user_id,
@@ -107,7 +108,7 @@ export async function testDocumentChanges()
 
     // setting document to test document
     console.log(`Setting initial document...`);
-    await updateDocument(SOURCE_DOCUMENT, PRIMARY_TEST_EMAIL);
+    await updateDocument(SOURCE_DOCUMENT, PRIMARY_TEST_ID);
     console.log(`Updating Document Color...`);
     await updateDocumentColor(id, "blue", user.user_email);
     console.log(`Updating cursor...`)
@@ -132,27 +133,27 @@ async function testLogIn(firebase: FirebaseWrapper)
 
 async function testDocumentUpdate(firebase: FirebaseWrapper)
 {
-    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_id);
     console.log(`Document Id: ${doc.metadata.document_id}`);
     TEST_DOCUMENT.metadata.document_id = doc.metadata.document_id;
-    await updateDocument(TEST_DOCUMENT, PRIMARY_TEST_EMAIL);
+    await updateDocument(TEST_DOCUMENT, PRIMARY_TEST_ID);
 
     const updatedDocumentTest = JSON.parse(JSON.stringify(TEST_DOCUMENT)) as Document;
 
     updatedDocumentTest.document_title = "New Document Title";
-    const success = await updateDocument(updatedDocumentTest, PRIMARY_TEST_EMAIL);
+    const success = await updateDocument(updatedDocumentTest, PRIMARY_TEST_ID);
     console.log(`Document Update was successful: ${success ? "true" : "false"}`);
 }
 
 async function testDocumentDeletion(firebase: FirebaseWrapper)
 {
-    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_id);
     console.log(`Document Id: ${doc.metadata.document_id}`);
-    await deleteDocument(doc, TEST_DOCUMENT.metadata.owner_email);
+    await deleteDocument(doc, TEST_DOCUMENT.metadata.owner_id);
 }
 
 async function testUserRegistrationToDocument(firebase: FirebaseWrapper) {
-    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    const doc = await createDocument(TEST_DOCUMENT.metadata.owner_id);
     const documentId = doc.metadata.document_id;
     console.log(`Document Id: ${documentId}`);
 
@@ -208,37 +209,37 @@ async function testDocumentMetadataUpdates(firebase: FirebaseWrapper)
 {
     // create the initial document
     const SOURCE_DOCUMENT = JSON.parse(JSON.stringify(TEST_DOCUMENT)) as Document;
-    const document = await createDocument(TEST_DOCUMENT.metadata.owner_email);
+    const document = await createDocument(TEST_DOCUMENT.metadata.owner_id);
     const id = document.metadata.document_id;
     SOURCE_DOCUMENT.metadata.document_id = id;
     console.log(`Document Id: ${id}`);
-    await updateDocument(SOURCE_DOCUMENT, PRIMARY_TEST_EMAIL);
+    await updateDocument(SOURCE_DOCUMENT, PRIMARY_TEST_ID);
 
     // update the metadata to alternative values
     await Promise.all([
-        updateDocumentShareStyle(id, SHARE_STYLE.edit_list, PRIMARY_TEST_EMAIL),
-        updateDocumentColor(id, "blue", PRIMARY_TEST_EMAIL),
-        updateDocumentEmoji(id, "&#x1f602", PRIMARY_TEST_EMAIL),
-        shareDocumentWithUser(id, SECONDARY_TEST_EMAIL, PRIMARY_TEST_EMAIL),
-        shareDocumentWithUser(id, TERTIARY_TEST_EMAIL, PRIMARY_TEST_EMAIL),
+        updateDocumentShareStyle(id, SHARE_STYLE.edit_list, PRIMARY_TEST_ID),
+        updateDocumentColor(id, "blue", PRIMARY_TEST_ID),
+        updateDocumentEmoji(id, "&#x1f602", PRIMARY_TEST_ID),
+        shareDocumentWithUser(id, SECONDARY_TEST_ID, PRIMARY_TEST_ID),
+        shareDocumentWithUser(id, TERTIARY_TEST_ID, PRIMARY_TEST_ID),
     ]);
-    await unshareDocumentWithUser(id, TERTIARY_TEST_EMAIL, PRIMARY_TEST_EMAIL);
-    await updateDocumentEmoji(id, ":celebration:", SECONDARY_TEST_EMAIL);
+    await unshareDocumentWithUser(id, TERTIARY_TEST_ID, PRIMARY_TEST_ID);
+    await updateDocumentEmoji(id, ":celebration:", SECONDARY_TEST_ID);
 
     // update source of truth
     SOURCE_DOCUMENT.metadata.share_style = SHARE_STYLE.edit_list;
     SOURCE_DOCUMENT.metadata.preview_color = "blue";
     SOURCE_DOCUMENT.metadata.preview_emoji = ":celebration:";
-    SOURCE_DOCUMENT.metadata.share_list = [SECONDARY_TEST_EMAIL];
+    SOURCE_DOCUMENT.metadata.share_list = [SECONDARY_TEST_ID];
 
     // grab the stored information
-    const databaseDocument = await getDocument(id, PRIMARY_TEST_EMAIL);
-    const secondaryUserShares = await getDocumentPreviewsSharedWithUser(SECONDARY_TEST_EMAIL);
-    const tertiaryUserShares = await getDocumentPreviewsSharedWithUser(TERTIARY_TEST_EMAIL);
+    const databaseDocument = await getDocument(id, PRIMARY_TEST_ID);
+    const secondaryUserShares = await getDocumentPreviewsSharedWithUser(SECONDARY_TEST_ID);
+    const tertiaryUserShares = await getDocumentPreviewsSharedWithUser(TERTIARY_TEST_ID);
 
     // verification checks
     SOURCE_DOCUMENT.metadata.last_edit_time = databaseDocument.metadata.last_edit_time;
-    SOURCE_DOCUMENT.metadata.last_edit_user = SECONDARY_TEST_EMAIL;
+    SOURCE_DOCUMENT.metadata.last_edit_user = SECONDARY_TEST_ID;
     assert(isEqual(SOURCE_DOCUMENT, databaseDocument), `Source document and firestore document are not equal`);
     // the shared document is in the shared list
     assert(secondaryUserShares

--- a/lib/documentTypes.ts
+++ b/lib/documentTypes.ts
@@ -11,7 +11,7 @@ export type Document =
 export type DocumentMetadata =
 {
     document_id: string,        // unique id associated with the document; used for firestore
-    owner_email: string,        // the user email of the user who created the document; unchanging field
+    owner_id: string,           // the user id of the user who created the document; unchanging field
     share_style: SHARE_STYLE,   // the type of publicity for the document
     share_list?: string[],      // OPTIONAL; the user list that the document is shared with
     time_created: number,       // the time (in milliseconds) when the document was created
@@ -36,7 +36,7 @@ export type Comment =
 {
     comment_id: string,
     content: string,
-    author_email: string,
+    author_id: string,
     is_reply: boolean,
     reply_id?: string,
     time_created: number,


### PR DESCRIPTION
# Summary

After running into another issue with using user emails as ids in the database, I decided it was time to convert everything to use user ids as the main ids. It was a pain, but I it'll hopefully end the issues I encountered in the database.


# Test Plan

I tested a couple of functions in the test file. I know I should test more comprehensively, but I don't feel like it right now. I will do a full check when I write unit tests for the backend.

-----
Please consider the impact of your changes on the other developers.