### PR TITLE
separate sharing by user from sharing by link or code

### DIFF
--- a/backend/src/document-utils/documentOperations.ts
+++ b/backend/src/document-utils/documentOperations.ts
@@ -1,5 +1,5 @@
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
-import { Document, DocumentMetadata, DocumentPreview, SHARE_STYLE } from '@lib/documentTypes'; 
+import { Document, DocumentMetadata, DocumentPreview, ShareStyle } from '@lib/documentTypes'; 
 import { userHasReadAccess, userHasWriteAccess } from '../security-utils/permissionVerification';
 import { getUserIdFromEmail } from "../user-utils/getUserData";
 import { recordOnlineUserUpdatedDocument } from "./realtimeOnlineUsers";
@@ -18,10 +18,11 @@ export async function createDocument(writerId: string): Promise<Document>
     const metadata: DocumentMetadata = {
         document_id: documentId,
         owner_id: writerId,
-        share_style: SHARE_STYLE.private_document,
+        share_link_style: ShareStyle.NONE,
         time_created: currentTime,
         last_edit_time: currentTime,
         last_edit_user: writerId,
+        share_list: {},
     };
     const document : Document = {
         document_title: "",
@@ -131,10 +132,10 @@ export async function deleteDocument(document: Document, writerId: string): Prom
     await firebase.deleteUserDocument(userId, documentId, true);
 
     // delete the document from the user shared documents
-    for(const sharedUser of (document.metadata.share_list ?? []))
+    for(const sharedUser of Object.keys(document.metadata.share_list))
     {
         await firebase.deleteUserDocument(sharedUser, documentId, false);
-    }
+    }   
 }
 
 // determines if a document exist in the Firestore database by attempting to retrieve it

--- a/backend/src/document-utils/updateDocumentMetadata.ts
+++ b/backend/src/document-utils/updateDocumentMetadata.ts
@@ -1,5 +1,5 @@
 // This file contains functions that will update the various metadata fields of a Document
-import { SHARE_STYLE } from "@lib/documentTypes";
+import { ShareStyle } from "@lib/documentTypes";
 import { processDocumentUpdate } from "./documentOperations";
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 
@@ -8,12 +8,12 @@ import "firebase/compat/firestore";
 
 export async function updateDocumentShareStyle(
   documentId: string,
-  newShareStyle: SHARE_STYLE,
+  newShareStyle: ShareStyle,
   writerId: string
 ) {
   await updateDocumentMetadata(
     documentId,
-    "share_style",
+    "share_link_style",
     newShareStyle,
     writerId
   );
@@ -45,39 +45,39 @@ export async function updateDocumentColor(
   );
 }
 
-// assumption: only call this function if the user is not already in the share list
 // assumption: only share with existing users
 export async function shareDocumentWithUser(
   documentId: string,
-  newUser: string,
+  userId: string,
+  shareStyle: ShareStyle,
   writerId: string
 ) {
   if (
     await updateDocumentMetadata(
       documentId,
-      "share_list",
-      firebase.firestore.FieldValue.arrayUnion(newUser),
+      `share_list.${userId}`,
+      shareStyle.valueOf(),
       writerId
     )
   ) {
-    await getFirebase().insertUserDocument(newUser, documentId, false);
+    await getFirebase().insertUserDocument(userId, documentId, false);
   }
 }
 
 export async function unshareDocumentWithUser(
   documentId: string,
-  oldUser: string,
+  userId: string,
   writerId: string
 ) {
   if (
     await updateDocumentMetadata(
       documentId,
-      "share_list",
-      firebase.firestore.FieldValue.arrayRemove(oldUser),
+      `share_list.${userId}`,
+      firebase.firestore.FieldValue.delete(),
       writerId
     )
   ) {
-    await getFirebase().deleteUserDocument(oldUser, documentId, false);
+    await getFirebase().deleteUserDocument(userId, documentId, false);
   }
 }
 

--- a/backend/src/scripts/refreshFirestoreUserAccessLists.ts
+++ b/backend/src/scripts/refreshFirestoreUserAccessLists.ts
@@ -3,7 +3,7 @@ import 'firebase/compat/auth';
 import 'firebase/compat/firestore';
 
 import { FIREBASE_CONFIG, DOCUMENT_DATABASE_NAME, USER_DATABASE_NAME } from '../firebaseSecrets'
-import { DocumentMetadata, SHARE_STYLE } from '@lib/documentTypes';
+import { DocumentMetadata, ShareStyle } from '@lib/documentTypes';
 
 // Purpose: recomputes the shared and owned documents lists for each user in Firestore
 // Note: this script can cause issues if the database is being actively updated
@@ -53,14 +53,7 @@ export async function refreshFirestoreUserAccessLists()
             batch.update(snapshot.ref, {'metadata.document_id': snapshot.id});
         }
         const owner = metadata.owner_id;
-        let shares: string[] = [];
-        if(
-            metadata.share_style === SHARE_STYLE.comment_list || 
-            metadata.share_style === SHARE_STYLE.edit_list || 
-            metadata.share_style === SHARE_STYLE.view_list
-        ){
-            shares = metadata.share_list ?? ([] as string[]);
-        }
+        let shares: string[] = Object.keys(metadata.share_list);
 
         updateMap(owner, owned, snapshot.id);
         shares.forEach((userId: string) => updateMap(userId, shared, snapshot.id));
@@ -97,7 +90,6 @@ export async function refreshFirestoreUserAccessLists()
         {
             batch.update(snapshot.ref, {'shared_documents': shared.get(snapshot.id) ?? ([] as string[])});
             console.log(`User ${snapshot.id} shared_documents is being updated to ${(shared.get(snapshot.id) ?? []).join(', ')}`);
-
         }
     }));
 

--- a/backend/src/security-utils/permissionVerification.ts
+++ b/backend/src/security-utils/permissionVerification.ts
@@ -1,53 +1,15 @@
-import { DocumentMetadata, SHARE_STYLE, Document } from "@lib/documentTypes";
-import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+import { DocumentMetadata, ShareStyle, Document } from "@lib/documentTypes";
 
 // returns true iff a user has read access
 // takes in the email of a user and the document to check
 export function userHasReadAccess(userId: string, document: Document): boolean {
-  const firebase = new FirebaseWrapper();
-  firebase.initApp();
-
-  const metadata: DocumentMetadata = document.metadata;
-  if (metadata === null) {
-    return false;
-  } else if (
-    metadata.owner_id === userId ||
-    metadata.share_style === SHARE_STYLE.public_document
-  ) {
-    return true;
-  } else if (
-    metadata.share_style === SHARE_STYLE.view_list ||
-    metadata.share_style === SHARE_STYLE.comment_list ||
-    metadata.share_style === SHARE_STYLE.edit_list
-  ) {
-    return metadata.share_list?.includes(userId) ?? false;
-  }
-
-  return false;
+  return highestPermissions(userId, document.metadata) >= ShareStyle.READ;
 }
 
 // returns true iff a user has comment access
 // takes in the email of a user and the document to check
 function userHasCommentAccess(userId: string, document: Document): boolean {
-  const firebase = new FirebaseWrapper();
-  firebase.initApp();
-
-  const metadata: DocumentMetadata = document.metadata;
-  if (metadata === null) {
-    return false;
-  } else if (
-    metadata.owner_id === userId ||
-    metadata.share_style === SHARE_STYLE.public_document
-  ) {
-    return true;
-  } else if (
-    metadata.share_style === SHARE_STYLE.comment_list ||
-    metadata.share_style === SHARE_STYLE.edit_list
-  ) {
-    return metadata.share_list?.includes(userId) ?? false;
-  }
-
-  return false;
+  return highestPermissions(userId, document.metadata) >= ShareStyle.COMMENT;
 }
 
 // returns true iff a user has edit access
@@ -56,20 +18,20 @@ export function userHasWriteAccess(
   userId: string,
   document: Document
 ): boolean {
-  const firebase = new FirebaseWrapper();
-  firebase.initApp();
+  return highestPermissions(userId, document.metadata) >= ShareStyle.WRITE;
+}
 
-  const metadata: DocumentMetadata = document.metadata;
+function highestPermissions(
+  userId: string,
+  metadata: DocumentMetadata
+): ShareStyle {
   if (metadata === null) {
-    return false;
-  } else if (
-    metadata.owner_id === userId ||
-    metadata.share_style === SHARE_STYLE.public_document
-  ) {
-    return true;
-  } else if (metadata.share_style === SHARE_STYLE.edit_list) {
-    return metadata.share_list?.includes(userId) ?? false;
+    return ShareStyle.NONE;
+  } else if (metadata.owner_id === userId) {
+    return ShareStyle.WRITE;
+  } else if (metadata.share_list[userId] !== undefined) {
+    return metadata.share_list[userId];
+  } else {
+    return metadata.share_link_style;
   }
-
-  return false;
 }

--- a/backend/src/tests/testController.ts
+++ b/backend/src/tests/testController.ts
@@ -1,5 +1,5 @@
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
-import { Document,  SHARE_STYLE } from '@lib/documentTypes';
+import { Document,  ShareStyle } from '@lib/documentTypes';
 import { createDocument, updateDocument, deleteDocument, getDocument } from '../document-utils/documentOperations';
 import { getDocumentPreviewsOwnedByUser, getDocumentPreviewsSharedWithUser } from "../document-utils/documentBatchRead";
 import { subscribeToDocument } from "../document-utils/realtimeDocumentUpdates";
@@ -45,7 +45,8 @@ const TEST_DOCUMENT: Document = {
     metadata: {
         document_id: "test_document_id",
         owner_id: PRIMARY_TEST_ID,
-        share_style: 1,
+        share_link_style: ShareStyle.NONE,
+        share_list: {},
         time_created: 0,
         last_edit_time: 12,
         last_edit_user: PRIMARY_TEST_ID,
@@ -217,20 +218,20 @@ async function testDocumentMetadataUpdates(firebase: FirebaseWrapper)
 
     // update the metadata to alternative values
     await Promise.all([
-        updateDocumentShareStyle(id, SHARE_STYLE.edit_list, PRIMARY_TEST_ID),
+        updateDocumentShareStyle(id, ShareStyle.WRITE, PRIMARY_TEST_ID),
         updateDocumentColor(id, "blue", PRIMARY_TEST_ID),
         updateDocumentEmoji(id, "&#x1f602", PRIMARY_TEST_ID),
-        shareDocumentWithUser(id, SECONDARY_TEST_ID, PRIMARY_TEST_ID),
-        shareDocumentWithUser(id, TERTIARY_TEST_ID, PRIMARY_TEST_ID),
+        shareDocumentWithUser(id, SECONDARY_TEST_ID, ShareStyle.WRITE, PRIMARY_TEST_ID),
+        shareDocumentWithUser(id, TERTIARY_TEST_ID, ShareStyle.COMMENT, PRIMARY_TEST_ID),
     ]);
     await unshareDocumentWithUser(id, TERTIARY_TEST_ID, PRIMARY_TEST_ID);
     await updateDocumentEmoji(id, ":celebration:", SECONDARY_TEST_ID);
 
     // update source of truth
-    SOURCE_DOCUMENT.metadata.share_style = SHARE_STYLE.edit_list;
+    SOURCE_DOCUMENT.metadata.share_link_style = ShareStyle.WRITE;
     SOURCE_DOCUMENT.metadata.preview_color = "blue";
     SOURCE_DOCUMENT.metadata.preview_emoji = ":celebration:";
-    SOURCE_DOCUMENT.metadata.share_list = [SECONDARY_TEST_ID];
+    SOURCE_DOCUMENT.metadata.share_list[SECONDARY_TEST_ID] = ShareStyle.WRITE;
 
     // grab the stored information
     const databaseDocument = await getDocument(id, PRIMARY_TEST_ID);

--- a/lib/documentTypes.ts
+++ b/lib/documentTypes.ts
@@ -1,34 +1,33 @@
 // purpose: for storing and representing a Composition Document
 export type Document =
 {
-    document_title: string,     // the title of the document; the label of the document used on the storage page
-    contents: JSON,             // the contents of the composition; the type is temporary (to be replaced later)
-    comments: Comment[],        // comments; unusued
-    metadata: DocumentMetadata, // the document metadata; this should be treated as a CONST by the frontend
+    document_title: string,             // the title of the document; the label of the document used on the storage page
+    contents: JSON,                     // the contents of the composition; the type is temporary (to be replaced later)
+    comments: Comment[],                // comments; unusued
+    metadata: DocumentMetadata,         // the document metadata; this should be treated as a CONST by the frontend
 };
 
 // purpose: for storing metadata about a composition document
 export type DocumentMetadata =
 {
-    document_id: string,        // unique id associated with the document; used for firestore
-    owner_id: string,           // the user id of the user who created the document; unchanging field
-    share_style: SHARE_STYLE,   // the type of publicity for the document
-    share_list?: string[],      // OPTIONAL; the user list that the document is shared with
-    time_created: number,       // the time (in milliseconds) when the document was created
-    last_edit_time: number,     // the time (in milliseconds) when the document was last updated
-    last_edit_user: string,     // the user that last updated the document
-    preview_emoji?: string,     // the emoji that represents this document | visible on the storage page
-    preview_color?: string,     // the color that the user chose for this document | visible on the storage page
+    document_id: string,                // unique id associated with the document; used for firestore
+    owner_id: string,                   // the user id of the user who created the document; unchanging field
+    time_created: number,               // the time (in milliseconds) when the document was created
+    last_edit_time: number,             // the time (in milliseconds) when the document was last updated
+    last_edit_user: string,             // the user that last updated the document
+    preview_emoji?: string,             // the emoji that represents this document | visible on the storage page
+    preview_color?: string,             // the color that the user chose for this document | visible on the storage page
+    share_link_style: ShareStyle,       // the type of publicity for the document (specific to links and share codes)
+    share_list: Record<string, ShareStyle>,      // the users that have access to the document and the permissions given to them
 };
 
 // purpose: for defining how a document has been shared
-export enum SHARE_STYLE 
+export enum ShareStyle 
 {
-    private_document = 1,   // the document has not been shared
-    public_document = 2,    // the document has been shared publically without the need to auth checks 
-    view_list = 3,          // the document can be viewed only by a select group of users
-    comment_list = 4,       // the document can be commented on (and viewed) by a select group of users
-    edit_list = 5,          // the document can be edited by (read/write access) a select group of users
+    NONE = 1,                           // the document has not been shared
+    READ = 2,                           // the document can be read by other users 
+    COMMENT = 3,                        // the document can be read and commented on by other users
+    WRITE = 4,                          // the document can be read, commented on, and edited by other users
 };
 
 // purpose: for storing information about comments inside a composition document


### PR DESCRIPTION
# Summary

Separated the logic for share links/codes and sharing with single users.  

Note: the share style with the user takes priority over the share link, even if the share link gives a higher priority. If we have anonymous users, this can be used to bypass the user allotted permissions, if applicable.

# Test Plan

Ran and fixed the single unit test in the test controller file.

-----
Please consider the impact of your changes on the other developers.