### PR TITLE
add access list for documents accessed through a code or link

### DIFF
--- a/backend/src/document-utils/documentBatchRead.ts
+++ b/backend/src/document-utils/documentBatchRead.ts
@@ -2,27 +2,28 @@ import { DocumentPreview } from '@lib/documentTypes';
 
 import { getDocumentPreview } from "./documentOperations";
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+import { AccessType } from '@lib/userTypes';
 
 // returns all documents created by the user associated with the userId
 export async function getDocumentPreviewsOwnedByUser(userId: string): Promise<DocumentPreview[]>
 {
-    return getDocumentPreviewsByUser(userId, true);
+    return getDocumentPreviewsByUser(userId, ["owned"]);
 }
 
 // returns all documents shared with the user associated with the userId
 // this function does not distinguish between view-only shares, comment-able shares, or edit shares
 export async function getDocumentPreviewsSharedWithUser(userId: string): Promise<DocumentPreview[]>
 {
-    return getDocumentPreviewsByUser(userId, false);
+    return getDocumentPreviewsByUser(userId, ["shared", "accessed"]);
 }
 
 // returns a list of DocumentPreviews that the user associated with the userId 
 // owns (if isOwned is true) or is shared with the user (if isOwned is false)
-async function getDocumentPreviewsByUser(userId: string, isOwned: boolean): Promise<DocumentPreview[]>
+async function getDocumentPreviewsByUser(userId: string, accessTypes: AccessType[]): Promise<DocumentPreview[]>
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
-    const documentIdList = await getDocumentIdsByUser(userId, isOwned);
+    const documentIdList = await getDocumentIdsByUser(userId, accessTypes);
     const documentList = [];
     for(const id of documentIdList)
     {
@@ -42,9 +43,9 @@ async function getDocumentPreviewsByUser(userId: string, isOwned: boolean): Prom
 
 // returns the list of document ids that is in the user's owned list (if isOwned is true) 
 // or shared with list (if isOwned is false)
-async function getDocumentIdsByUser(userId: string, isOwned: boolean): Promise<string[]>
+async function getDocumentIdsByUser(userId: string, accessTypes: AccessType[]): Promise<string[]>
 {
     const firebase = new FirebaseWrapper();
     firebase.initApp();
-    return await firebase.getUserDocuments(userId, isOwned);
+    return await firebase.getUserDocuments(userId, accessTypes);
 }

--- a/backend/src/document-utils/updateDocumentMetadata.ts
+++ b/backend/src/document-utils/updateDocumentMetadata.ts
@@ -61,7 +61,7 @@ export async function shareDocumentWithUser(
       writerId
     )
   ) {
-    await getFirebase().insertUserDocument(userId, documentId, false);
+    await getFirebase().insertUserDocument(userId, documentId, "shared");
   }
 }
 
@@ -78,7 +78,7 @@ export async function unshareDocumentWithUser(
       writerId
     )
   ) {
-    await getFirebase().deleteUserDocument(userId, documentId, false);
+    await getFirebase().deleteUserDocument(userId, documentId, "shared");
   }
 }
 

--- a/backend/src/scripts/refreshFirestoreUserAccessLists.ts
+++ b/backend/src/scripts/refreshFirestoreUserAccessLists.ts
@@ -1,3 +1,8 @@
+/**
+ * TO DO:
+ *  retest script
+ *  automate deletion of removed documents from access list
+ */
 import firebase from 'firebase/compat/app'
 import 'firebase/compat/auth';
 import 'firebase/compat/firestore';

--- a/lib/userTypes.ts
+++ b/lib/userTypes.ts
@@ -7,7 +7,14 @@ export type UserEntity =
     account_creation_time: number,      // the time (in milliseconds) when this account was created
     owned_documents: string[],          // a list of the document ids associated with all documents that the user created
     shared_documents: string[],         // a list of the document ids associated with all documents that have been shared with this user
+    accessed_documents: string[],       // a list of the document ids that were accessed by this user without being explicitly shared
 };
+
+// the way a user got access to a document (and the associated field name in Firestore) 
+// owned: the user created the document
+// shared: the user was given access to the document explicitly through email
+// accessed: the user accessed the document through a link or share code
+export type AccessType =  "owned" | "shared" | "accessed";
 
 // purpose: returns the default user (ie a blank user) for use in account creation
 // this helps populate the database with the default user information 
@@ -19,6 +26,7 @@ export function getDefaultUser(): UserEntity
         display_name: "",
         owned_documents: [],
         shared_documents: [],
+        accessed_documents: [],
         account_creation_time: Date.now()
     }
 }


### PR DESCRIPTION
# Summary

Added a list in the UserEntity type specifically for holding document ids of documents accessed through links or codes instead of by being shared directly.  This list is updated whenever a user "gets" a document that has a non-private share style and that user is not the owner or on the share list.

# Test Plan

Unit test. I also added a part of the unit test that specifically checks for adding/removing access list documents.

-----
Please consider the impact of your changes on the other developers.