### PR TITLE
user level document properties

### DIFF
--- a/backend/src/document-utils/documentBatchRead.ts
+++ b/backend/src/document-utils/documentBatchRead.ts
@@ -1,16 +1,16 @@
-import { DocumentPreview } from "@lib/src/documentProperties";
+import { DocumentPreview, UserLevelDocumentProperties } from "@lib/src/documentProperties";
 
-import { getDocumentPreview } from "./documentOperations";
 import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
 import { AccessType } from "@lib/src/UserEntity";
+import { getDocument } from "./documentOperations";
 
 // returns all documents created by the user associated with the userId
 export async function getDocumentPreviewsOwnedByUser(
   userId: string
 ): Promise<DocumentPreview[]> {
     return (await getDocumentPreviewsByUser(userId, ["owned"])).filter(
-    (preview) => !preview.is_trashed
-);
+        (preview) => !preview.is_trashed
+    );
 }
 
 // returns all documents shared with the user associated with the userId
@@ -19,8 +19,8 @@ export async function getDocumentPreviewsSharedWithUser(
     userId: string
 ): Promise<DocumentPreview[]> {
     return (
-    await getDocumentPreviewsByUser(userId, ["shared", "accessed"])
-).filter((preview) => !preview.is_trashed);
+        await getDocumentPreviewsByUser(userId, ["shared", "accessed"])
+    ).filter((preview) => !preview.is_trashed);
 }
 
 /**
@@ -44,10 +44,24 @@ async function getDocumentPreviewsByUser(
   const firebase = new FirebaseWrapper();
   firebase.initApp();
   const documentIdList = await getDocumentIdsByUser(userId, accessTypes);
+  const user = await firebase.getUser(userId);
+
+  if(user === null)
+  {
+    console.warn(`Could not access user ${userId}`);
+    return [];
+  }
+  const documentProperties = user?.preview_properties;
+
   const documentList = [];
   for (const id of documentIdList) {
     try {
-      const document = await getDocumentPreview(id, userId);
+      const document = await createDocumentPreview(
+        id, 
+        userId, 
+        documentProperties ? (documentProperties as any)[id] : undefined
+      );
+
       if (document === null || document === undefined) {
         continue;
       }
@@ -61,6 +75,24 @@ async function getDocumentPreviewsByUser(
   return documentList;
 }
 
+// gets a Document and extracts and returns its DocumentPreview
+export async function createDocumentPreview(
+    documentId: string, 
+    readerId: string, 
+    userLevelProperties: UserLevelDocumentProperties | undefined
+): Promise<DocumentPreview> {
+    const document = await getDocument(documentId, readerId);
+
+    let userLevel = userLevelProperties ?? { is_favorited: false };
+    if(userLevel.is_favorited === undefined) userLevel.is_favorited = false;
+
+    return {
+        ...document.metadata, 
+        ...{document_title: document.document_title},
+        ...userLevel,
+    };
+}
+
 // returns the list of document ids that is in the user's owned list (if isOwned is true)
 // or shared with list (if isOwned is false)
 async function getDocumentIdsByUser(
@@ -71,3 +103,28 @@ async function getDocumentIdsByUser(
   firebase.initApp();
   return await firebase.getUserDocuments(userId, accessTypes);
 }
+
+export async function getSingleDocumentPreview(
+    documentId: string, 
+    userId: string
+): Promise<DocumentPreview> {
+    const document = await getDocument(documentId, userId);
+    const user = (await getFirebase().getUser(userId))?.preview_properties;
+    
+    let userLevel = user ? (user as any)[documentId] : { is_favorited: false };
+    if(userLevel === undefined) userLevel = { is_favorited: false };
+    if(userLevel.is_favorited === undefined) userLevel.is_favorited = false;
+
+    return {
+        ...document.metadata, 
+        ...{document_title: document.document_title},
+        ...userLevel,
+    };
+}
+
+const getFirebase = (): FirebaseWrapper => {
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+    return firebase;
+  };
+  

--- a/backend/src/document-utils/documentOperations.ts
+++ b/backend/src/document-utils/documentOperations.ts
@@ -24,7 +24,6 @@ export async function createDocument(writerId: string): Promise<Document>
         time_created: currentTime,
         last_edit_time: currentTime,
         last_edit_user: writerId,
-        is_favorited: false,
         is_trashed: false,
         share_list: {},
     };
@@ -107,16 +106,6 @@ export async function getDocument(documentId: string, readerId: string): Promise
         await firebase.insertUserDocument(readerId, firebaseDocument.metadata.document_id, "accessed");
     }
     return firebaseDocument;
-}
-
-// gets a Document and extracts and returns its DocumentPreview
-export async function getDocumentPreview(documentId: string, readerId: string): Promise<DocumentPreview>
-{
-    const document = await getDocument(documentId, readerId);
-    return {
-        ...document.metadata, 
-        ...{document_title: document.document_title}
-    };
 }
 
 // deletes the document associated with the given document id

--- a/backend/src/document-utils/updateDocumentMetadata.ts
+++ b/backend/src/document-utils/updateDocumentMetadata.ts
@@ -20,32 +20,6 @@ export async function updateDocumentShareStyle(
   );
 }
 
-export async function updateDocumentEmoji(
-  documentId: string,
-  newEmoji: string,
-  writerId: string
-) {
-  await updateDocumentMetadata(
-    documentId,
-    "preview_emoji",
-    newEmoji,
-    writerId
-  );
-}
-
-export async function updateDocumentColor(
-  documentId: string,
-  newColor: string,
-  writerId: string
-) {
-  await updateDocumentMetadata(
-    documentId,
-    "preview_color",
-    newColor,
-    writerId
-  );
-}
-
 // assumption: only share with existing users
 export async function shareDocumentWithUser(
   documentId: string,
@@ -80,19 +54,6 @@ export async function unshareDocumentWithUser(
   ) {
     await getFirebase().deleteUserDocument(userId, documentId, "shared");
   }
-}
-
-export async function updateDocumentFavoritedStatus(
-  documentId: string,
-  isFavorited: boolean,
-  writerId: string
-) {
-  await updateDocumentMetadata(
-    documentId,
-    "is_favorited",
-    isFavorited,
-    writerId
-  );
 }
 
 // ASSUMPTION: ONLY LET AUTHOR TRASH THEIR DOCUMENT

--- a/backend/src/document-utils/updateUserLevelDocumentProperties.ts
+++ b/backend/src/document-utils/updateUserLevelDocumentProperties.ts
@@ -1,0 +1,60 @@
+import firebase from "firebase/compat/app";
+import "firebase/compat/firestore";
+
+import { UserLevelDocumentProperties } from "@lib/src/documentProperties";
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+
+export async function updateDocumentEmoji(
+  documentId: string,
+  newEmoji: string,
+  writerId: string
+) {
+  await updateUserLevelDocumentProperty(
+    documentId,
+    "preview_emoji",
+    newEmoji,
+    writerId
+  );
+}
+
+export async function updateDocumentColor(
+  documentId: string,
+  newColor: string,
+  writerId: string
+) {
+  await updateUserLevelDocumentProperty(
+    documentId,
+    "preview_color",
+    newColor,
+    writerId
+  );
+}
+
+export async function updateDocumentFavoritedStatus(
+  documentId: string,
+  isFavorited: boolean,
+  writerId: string
+) {
+  await updateUserLevelDocumentProperty(
+    documentId,
+    "is_favorited",
+    isFavorited,
+    writerId
+  );
+}
+
+// generic version of all the other functions in this file; updates a user level property field for a document
+async function updateUserLevelDocumentProperty(
+    documentId: string,
+    property: keyof UserLevelDocumentProperties,
+    newValue: unknown,
+    userId: string
+  ) {
+    await getFirebase().updateUserLevelProperty(userId, documentId, property, newValue);
+  }
+  
+const getFirebase = (): FirebaseWrapper => {
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+    return firebase;
+};

--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -274,6 +274,14 @@ export default class FirebaseWrapper
         await this.updateDataInFirestore(USER_DATABASE_NAME, userId, updatedObject);
     }
 
+    public async updateUserLevelProperty(userId: string, documentId: string, property: string, value: unknown)
+    {
+        const updateObject = {
+            [`preview_properties.${documentId}.${property}`]: value
+        };
+        await this.updateDataInFirestore(USER_DATABASE_NAME, userId, updateObject);
+    }
+
     // NOT FOR EXTERNAL USE (use the subscription fn in documentOperations.ts instead)
     // wrapper for the document subscription
     public async subscribeToDocument(

--- a/lib/src/UserEntity.ts
+++ b/lib/src/UserEntity.ts
@@ -1,13 +1,16 @@
+import { UserLevelDocumentProperties } from "./documentProperties";
+
 //the UserEntity is the collection of information associated with a user account
 export type UserEntity =
 {
-    user_id: string,                    // the id of the user (Firebase makes one for each registered user)
-    user_email: string,                 // the email associated with this user account
-    display_name: string,               // the display name for this user
-    account_creation_time: number,      // the time (in milliseconds) when this account was created
-    owned_documents: string[],          // a list of the document ids associated with all documents that the user created
-    shared_documents: string[],         // a list of the document ids associated with all documents that have been shared with this user
-    accessed_documents: string[],       // a list of the document ids that were accessed by this user without being explicitly shared
+    user_id: string,                  // the id of the user (Firebase makes one for each registered user)
+    user_email: string,               // the email associated with this user account
+    display_name: string,             // the display name for this user
+    account_creation_time: number,    // the time (in milliseconds) when this account was created
+    owned_documents: string[],        // a list of the document ids associated with all documents that the user created
+    shared_documents: string[],       // a list of the document ids associated with all documents that have been shared with this user
+    accessed_documents: string[],     // a list of the document ids that were accessed by this user without being explicitly shared
+    preview_properties: Record<string, UserLevelDocumentProperties> // a map of document ids to the user level properties chosen by the user
 };
 
 // the way a user got access to a document (and the associated field name in Firestore) 
@@ -21,12 +24,13 @@ export type AccessType =  "owned" | "shared" | "accessed";
 export function getDefaultUser(): UserEntity
 {
     return {
+        account_creation_time: Date.now(),
         user_id: "",
         user_email: "",
         display_name: "",
         owned_documents: [],
         shared_documents: [],
         accessed_documents: [],
-        account_creation_time: Date.now()
+        preview_properties: {},
     }
 }

--- a/lib/src/documentProperties.ts
+++ b/lib/src/documentProperties.ts
@@ -9,9 +9,6 @@ export type DocumentMetadata =
     is_trashed: boolean,                // whether or not the user has trashed the document
     share_link_style: ShareStyle,       // the type of publicity for the document (specific to links and share codes)
     share_list: Record<string, ShareStyle>,      // the users that have access to the document and the permissions given to them
-    is_favorited: boolean,              // whether or not the user has starred/favorited the document
-    preview_emoji?: string,             // the emoji that represents this document | visible on the storage page
-    preview_color?: string,             // the color that the user chose for this document | visible on the storage page
 };
 
 // purpose: for defining how a document has been shared
@@ -23,5 +20,13 @@ export enum ShareStyle
     WRITE = 4,                          // the document can be read, commented on, and edited by other users
 };
 
+// purpose: the properties of a document that are local to a user
+export type UserLevelDocumentProperties =
+{
+    is_favorited: boolean,              // whether or not the user has starred/favorited the document
+    preview_emoji?: string,             // the emoji that represents this document | visible on the storage page
+    preview_color?: string,             // the color that the user chose for this document | visible on the storage page
+};
+
 // purpose: the preview information of a document for use on a user's storage page
-export type DocumentPreview = DocumentMetadata & { document_title: string };
+export type DocumentPreview = DocumentMetadata & { document_title: string } & UserLevelDocumentProperties;


### PR DESCRIPTION
# Summary

Made `is_favorited`, `preview_emoji`, and `preview_color` into user-level properties, such that they are localized to just a single user. This way, a user editing their preview, does not impact another user's preview.

# Test Plan

Added a unit test and updated previous unit tests. Ran them, fixed bugs, and ensured no errors thrown.

-----
Please consider the impact of your changes on the other developers.