### PR TITLE
add CRUD operations and subscription for comments

### DIFF
--- a/backend/src/comment-utils/commentOperations.ts
+++ b/backend/src/comment-utils/commentOperations.ts
@@ -1,0 +1,100 @@
+
+import { Comment } from "@lib/src/Comment";
+import { UpdateType } from "@lib/src/UpdateType";
+
+import FirebaseWrapper from "../firebase-utils/FirebaseWrapper";
+import { recordOnlineUserUpdatedDocument } from "../document-utils/realtimeOnlineUsers";
+import { userHasCommentAccess } from "../security-utils/permissionVerification";
+
+// creates a comment and returns the comment id
+// replyId is the id of the direct parent comment (the one being replied to) or null if this comment is not a reply
+export async function createComment(
+    commentText: string, 
+    replyId: string | null, 
+    user: {user_id: string, display_name: string}, 
+    documentId: string, 
+): Promise<string> {
+    if(!(await hasCommentPermissions(user.user_id, documentId)))
+    {
+        throw Error(`User ${user.user_id} does not have permissions to comment on document ${documentId}`);
+    }
+
+    const commentId = await getFirebase().createComment({
+        text: commentText,
+        author_id: user.user_id,
+        author_display_name: user.display_name,
+        is_reply: replyId !== null,
+        ...(replyId ? { reply_id: replyId } : {}),
+    }, documentId);
+    await recordOnlineUserUpdatedDocument(documentId, user);
+
+    return commentId;
+}
+
+// deletes a comment
+// userId is the id of the user doing the deletion. This function does not validate if they are allowed to delete the particular comment.
+export async function deleteComment(
+    commentId: string,
+    documentId: string,
+    userId: string
+): Promise<boolean> {
+    if(!(await hasCommentPermissions(userId, documentId)))
+    {
+        throw Error(`User ${userId} does not have permissions to comment on document ${documentId}`);
+    }
+
+    await getFirebase().deleteComment(commentId, documentId);
+    await recordOnlineUserUpdatedDocument(documentId, {user_id: userId});
+
+    return true;
+}
+
+// resets the text of a comment
+// user id should be both the author id and the editor id (please check that they are the same person)
+export async function editCommentText(
+    newText: string,
+    commentId: string,
+    documentId: string,
+    userId: string,
+) {
+    if(!(await hasCommentPermissions(userId, documentId)))
+    {
+        throw Error(`User ${userId} does not have permissions to comment on document ${documentId}`);
+    }
+
+    await getFirebase().updateComment({
+        text: newText,
+        comment_id: commentId,
+    }, documentId);
+    await recordOnlineUserUpdatedDocument(documentId, {user_id: userId});
+}
+
+// subscribe to the "pool" of comments of a particular document
+export async function subscribeToComments(
+    documentId: string,
+    userId: string,
+    updateCommentFn: (updateType: UpdateType, comment: Comment) => void
+) {
+    if(!(await hasCommentPermissions(userId, documentId)))
+    {
+        throw Error(`User ${userId} does not have permissions to comment on document ${documentId}`);
+    }
+
+    await getFirebase().subscribeToDocumentComments(documentId, updateCommentFn);
+}
+
+const getFirebase = (): FirebaseWrapper => {
+    const firebase = new FirebaseWrapper();
+    firebase.initApp();
+    return firebase;
+};
+
+async function hasCommentPermissions(userId: string, documentId: string): Promise<boolean> {
+    const document = await getFirebase().getDocument(documentId);
+    if(document === null)
+    {
+        return false;
+    }
+
+    return await userHasCommentAccess(userId, document);
+}

--- a/backend/src/document-utils/realtimeDocumentUpdates.ts
+++ b/backend/src/document-utils/realtimeDocumentUpdates.ts
@@ -42,7 +42,7 @@ export async function subscribeToDocument(
           throw Error(`User with id ${user.user_id} does not have read access to document with id ${document.metadata.document_id}`)
       } else if(firstAccess) {
         firstAccess = false;
-        processFirstAccessAndAuth(user, document, firebase);
+        processFirstAccess(user, document, firebase);
       }
       
       onDocumentUpdateFn(document as Document);
@@ -51,7 +51,7 @@ export async function subscribeToDocument(
 }
 
 // NOTE: ACCESS LIST INSERTION IS NOT AWAITED ON
-function processFirstAccessAndAuth(
+function processFirstAccess(
   user: Record<string, unknown> & Required<Pick<UserEntity, 'user_id' | 'user_email' | 'display_name'>>,
   document: Document,
   firebase: FirebaseWrapper

--- a/backend/src/document-utils/realtimeOnlineUsers.ts
+++ b/backend/src/document-utils/realtimeOnlineUsers.ts
@@ -42,9 +42,10 @@ export async function recordOnlineUserUpdatedDocument(
     
     // check if document exists (TO DO: remove the need for this check)
     if(!firebase.doesDocumentExist(documentId)) {
-        throw Error(
+        console.error(
             `Trying to register user ${onlineUser.user_id} to nonexistant document ${documentId}`
         );
+        return;
     }
     
     // update the online user information in firebase

--- a/backend/src/firebase-utils/FirebaseWrapper.ts
+++ b/backend/src/firebase-utils/FirebaseWrapper.ts
@@ -3,6 +3,7 @@ import 'firebase/compat/auth';
 import "firebase/compat/database";
 import 'firebase/compat/firestore';
 
+import { Comment } from '@lib/src/Comment';
 import { DocumentMetadata } from '@lib/src/documentProperties';
 import { Document } from '@lib/src/Document';
 import { OnlineEntity } from "@lib/src/realtimeUserTypes";
@@ -15,10 +16,12 @@ import {
     SHARE_CODE_DATABASE,
     USER_DATABASE_NAME
 } from '../firebaseSecrets'
-import { ShareCodeEntity } from 'src/document-utils/sharing/ShareCodeEntity';
+import { ShareCodeEntity } from '../document-utils/sharing/ShareCodeEntity';
 
 type PartialWithRequired<T, K extends keyof T> = Partial<T> & Required<Pick<T, K>>;
 type PartialWithRequiredAndWithout<T, K extends keyof T, U extends keyof T> = Partial<T> & Required<Omit<Pick<T, K>, U>>;
+
+const COMMENT_DATABASE_NAME = "Comments_Collection";
 
 /*
     Wrapper class for doing firebase stuff
@@ -163,6 +166,7 @@ export default class FirebaseWrapper
             .firestore()
             .collection(DOCUMENT_DATABASE_NAME)
             .add({});
+        
         return firestoreDocument.id;
     }
 
@@ -208,6 +212,7 @@ export default class FirebaseWrapper
     public async deleteDocument(documentId: string): Promise<void>
     {
         await firebase.firestore().collection(DOCUMENT_DATABASE_NAME).doc(documentId).delete();
+        await firebase.firestore().collection(COMMENT_DATABASE_NAME).doc(documentId).delete();
     }
 
     public async getUser(userId: string): Promise<UserEntity> {
@@ -363,5 +368,73 @@ export default class FirebaseWrapper
     public async deleteShareCodeEntity(shareCode: string)
     {
         return this.deleteDataFromFirestore(SHARE_CODE_DATABASE, shareCode);
+    }
+    
+    public async createComment(comment: Partial<Comment>, documentId: string): Promise<string>
+    {
+        const docRef = firebase
+                            .firestore()
+                            .collection(COMMENT_DATABASE_NAME)
+                            .doc(documentId)
+                            .collection(COMMENT_DATABASE_NAME)
+                            .doc();
+                            
+        const doc = await docRef.set({
+                                ...comment,
+                                time_created: Date.now(),
+                                last_edit_time: Date.now(),
+                                comment_id: docRef.id
+                            });
+        // return id
+        return docRef.id;
+    }
+
+    public async updateComment(comment: PartialWithRequiredAndWithout<Comment, 'comment_id', 'last_edit_time'>, documentId: string)
+    {
+        await firebase
+                .firestore()
+                .collection(COMMENT_DATABASE_NAME)
+                .doc(documentId)
+                .collection(COMMENT_DATABASE_NAME)
+                .doc(comment.comment_id)
+                .update({
+                    ...comment,
+                    last_edit_time: firebase.firestore.FieldValue.serverTimestamp(),
+                });
+    }
+
+    public async deleteComment(commentId: string, documentId: string)
+    {
+        await firebase
+                .firestore()
+                .collection(COMMENT_DATABASE_NAME)
+                .doc(documentId)
+                .collection(COMMENT_DATABASE_NAME)
+                .doc(commentId)
+                .delete();
+    }
+
+    public async subscribeToDocumentComments(
+        documentId: string, 
+        commentUpdateFn: (updateType: UpdateType, updatedComment: Comment) => void 
+    ) {
+        firebase
+            .firestore()
+            .collection(COMMENT_DATABASE_NAME)
+            .doc(documentId)
+            .collection(COMMENT_DATABASE_NAME)
+            .onSnapshot( (querySnapshot) => {
+                querySnapshot.docChanges().forEach((change) => {
+                    if(change.type === 'added') {
+                        commentUpdateFn(UpdateType.ADD, change.doc.data() as Comment);
+                    } else if(change.type === 'modified') {
+                        commentUpdateFn(UpdateType.CHANGE, change.doc.data() as Comment);
+                    } else if(change.type === 'removed') {
+                        commentUpdateFn(UpdateType.DELETE, change.doc.data() as Comment);
+                    } else {
+                        console.warn(`Encountered an update type ${change.type} when subscribed to comments. Skipping due to unknown type.`);
+                    }
+                })
+            });
     }
 }

--- a/backend/src/security-utils/permissionVerification.ts
+++ b/backend/src/security-utils/permissionVerification.ts
@@ -9,7 +9,7 @@ export function userHasReadAccess(userId: string, document: Document): boolean {
 
 // returns true iff a user has comment access
 // takes in the email of a user and the document to check
-function userHasCommentAccess(userId: string, document: Document): boolean {
+export function userHasCommentAccess(userId: string, document: Document): boolean {
   return highestPermissions(userId, document.metadata) >= ShareStyle.COMMENT;
 }
 

--- a/lib/src/Comment.ts
+++ b/lib/src/Comment.ts
@@ -2,8 +2,9 @@
 export type Comment = 
 {
     comment_id: string,
-    content: string,
+    text: string,
     author_id: string,
+    author_display_name: string,
     is_reply: boolean,
     reply_id?: string,
     time_created: number,

--- a/lib/src/documentProperties.ts
+++ b/lib/src/documentProperties.ts
@@ -12,7 +12,7 @@ export type DocumentMetadata =
 };
 
 // purpose: for defining how a document has been shared
-export enum ShareStyle 
+export enum ShareStyle
 {
     NONE = 1,                           // the document has not been shared
     READ = 2,                           // the document can be read by other users 


### PR DESCRIPTION
# Summary

CRUD operations for comments.  Currently, you can only "get" a comment, if you subscribe to a document's pool of comments.

# Test Plan

Created a unit test, ran, debugged...


-----
Please consider the impact of your changes on the other developers.